### PR TITLE
feat(pgqueue): metadata-ingestion sink and actions pg_queue event source

### DIFF
--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -46,6 +46,8 @@ lint_requirements = {
 
 base_requirements = {
     f"acryl-datahub[datahub-kafka]{_self_pin}",
+    # pg_queue event source imports metadata-ingestion connection helpers that require psycopg2.
+    "psycopg2-binary<3.0.0",
     # Actual dependencies.
     "typing-inspect",
     "pydantic>=2.4.0,<3.0.0",

--- a/datahub-actions/src/datahub_actions/plugin/source/pgqueue/__init__.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/pgqueue/__init__.py
@@ -1,0 +1,1 @@
+# PostgreSQL queue event source (metadata-ingestion pgQueue DDL + Avro payloads).

--- a/datahub-actions/src/datahub_actions/plugin/source/pgqueue/pg_queue_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/pgqueue/pg_queue_event_source.py
@@ -1,0 +1,198 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from pydantic import Field
+
+from datahub.configuration import ConfigModel
+from datahub.configuration.kafka import _get_schema_registry_url
+from datahub.emitter.serialization_helper import post_json_transform
+from datahub.metadata.schema_classes import GenericPayloadClass, MetadataChangeLogClass
+from datahub.pgqueue.config import (
+    PayloadRouteKind,
+    PgQueueConnectionConfig,
+    PgQueueConsumerConfig,
+)
+from datahub.pgqueue.consumer import (
+    DatahubPgQueueConsumer,
+    PgQueueConsumedRecord,
+    build_pg_queue_event_meta,
+)
+from datahub.pgqueue.repository import PgQueueMessageHandle
+from datahub_actions.event.event_envelope import EventEnvelope
+from datahub_actions.event.event_registry import (
+    ENTITY_CHANGE_EVENT_V1_TYPE,
+    METADATA_CHANGE_LOG_EVENT_V1_TYPE,
+    RELATIONSHIP_CHANGE_EVENT_V1_TYPE,
+    MetadataChangeLogEvent,
+    RelationshipChangeEvent,
+)
+from datahub_actions.pipeline.pipeline_context import PipelineContext
+from datahub_actions.plugin.source.kafka.kafka_event_source import (
+    DEFAULT_TOPIC_ROUTES,
+    ENTITY_CHANGE_EVENT_NAME,
+    RELATIONSHIP_CHANGE_EVENT_NAME,
+    build_entity_change_event,
+)
+from datahub_actions.source.event_source import EventSource
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PG_QUEUE_PAYLOAD_KINDS: Dict[str, PayloadRouteKind] = {
+    "mcl": "mcl",
+    "mcl_timeseries": "mcl",
+    "pe": "pe",
+}
+
+
+class PgQueueEventSourceConfig(ConfigModel):
+    queue: PgQueueConnectionConfig
+    schema_registry_url: str = Field(default_factory=_get_schema_registry_url)
+    schema_registry_config: Dict[str, object] = Field(default_factory=dict)
+    topic_routes: Dict[str, str] = Field(
+        default_factory=lambda: dict(DEFAULT_TOPIC_ROUTES),
+        description="Logical route keys (mcl, pe, …) → logical topic names in pgQueue.",
+    )
+    payload_kind_by_route_key: Dict[str, PayloadRouteKind] = Field(
+        default_factory=lambda: dict(_DEFAULT_PG_QUEUE_PAYLOAD_KINDS),
+    )
+    visibility_timeout_seconds: Optional[int] = Field(
+        default=None,
+        description="Override queue visibility timeout when set.",
+    )
+    poll_interval_seconds: float = Field(default=2.0, ge=0.1, le=120.0)
+    batch_size: int = Field(default=100, ge=1, le=5000)
+
+    def build_consumer_config(self, pipeline_name: str) -> PgQueueConsumerConfig:
+        return PgQueueConsumerConfig(
+            queue=self.queue,
+            schema_registry_url=self.schema_registry_url,
+            schema_registry_config=dict(self.schema_registry_config),
+            topic_routes=dict(self.topic_routes),
+            consumer_group=pipeline_name,
+            visibility_timeout_seconds=self.visibility_timeout_seconds,
+            payload_kind_by_route_key=dict(self.payload_kind_by_route_key),
+        )
+
+
+@dataclass
+class PgQueueEventSource(EventSource):
+    """Poll pgQueue using metadata-ingestion client; emits the same envelopes as Kafka source."""
+
+    source_config: PgQueueEventSourceConfig = field(init=False)
+    ctx: PipelineContext = field(init=False)
+    _consumer: Optional[DatahubPgQueueConsumer] = field(
+        default=None, init=False, repr=False
+    )
+    running: bool = field(default=False, init=False)
+
+    def __init__(self, config: PgQueueEventSourceConfig, ctx: PipelineContext):
+        self.source_config = config
+        self.ctx = ctx
+        consumer_cfg = config.build_consumer_config(ctx.pipeline_name)
+        self._consumer = DatahubPgQueueConsumer(consumer_cfg)
+
+    @classmethod
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> PgQueueEventSource:
+        cfg = PgQueueEventSourceConfig.model_validate(config_dict)
+        return cls(cfg, ctx)
+
+    def events(self) -> Iterable[EventEnvelope]:
+        if self._consumer is None:
+            raise RuntimeError("pgQueue consumer is not initialized")
+
+        routes = self.source_config.topic_routes
+        preferred = ("mcl", "mcl_timeseries", "pe")
+        route_order = [k for k in preferred if k in routes]
+        for k in routes:
+            if k not in route_order:
+                route_order.append(k)
+
+        self.running = True
+        logger.info(
+            "pgQueue actions source started for pipeline '%s', routes=%s",
+            self.ctx.pipeline_name,
+            route_order,
+        )
+        while self.running:
+            batch = self._consumer.poll_route_keys(
+                route_order, max_messages=self.source_config.batch_size
+            )
+            if batch:
+                for rec in batch:
+                    yield from self._records_to_envelopes(rec)
+            else:
+                time.sleep(self.source_config.poll_interval_seconds)
+
+        logger.info("pgQueue consumer exiting main loop")
+
+    def _records_to_envelopes(
+        self, rec: PgQueueConsumedRecord
+    ) -> Iterable[EventEnvelope]:
+        meta = build_pg_queue_event_meta(rec)
+        if isinstance(rec.record, MetadataChangeLogClass):
+            mcl_event = MetadataChangeLogEvent.from_class(rec.record)
+            yield EventEnvelope(METADATA_CHANGE_LOG_EVENT_V1_TYPE, mcl_event, meta)
+            return
+        if isinstance(rec.record, dict):
+            yield from self._platform_event_envelopes(rec.record, meta)
+            return
+        logger.warning(
+            "Unexpected pgQueue payload type %s for topic %s",
+            type(rec.record),
+            rec.topic_name,
+        )
+
+    def _platform_event_envelopes(
+        self, value: Dict[str, Any], meta: Dict[str, Any]
+    ) -> Iterable[EventEnvelope]:
+        payload: GenericPayloadClass = GenericPayloadClass.from_obj(
+            post_json_transform(value["payload"])
+        )
+        name = value["name"]
+        if ENTITY_CHANGE_EVENT_NAME == name:
+            ece = build_entity_change_event(payload)
+            yield EventEnvelope(ENTITY_CHANGE_EVENT_V1_TYPE, ece, meta)
+        elif RELATIONSHIP_CHANGE_EVENT_NAME == name:
+            rce = RelationshipChangeEvent.from_json(payload.get("value"))
+            yield EventEnvelope(RELATIONSHIP_CHANGE_EVENT_V1_TYPE, rce, meta)
+
+    def ack(self, event: EventEnvelope, processed: bool = True) -> None:
+        self.ack_many((event,), processed=processed)
+
+    def ack_many(self, events: Sequence[EventEnvelope], processed: bool = True) -> None:
+        """Acknowledge multiple envelopes in one pgQueue round-trip when possible."""
+        if not processed or self._consumer is None or not events:
+            return
+        handles: List[PgQueueMessageHandle] = []
+        for event in events:
+            pq = event.meta.get("pg_queue") if event.meta else None
+            if not pq or "handle" not in pq:
+                logger.warning("Missing pg_queue meta; skip ack for one event")
+                continue
+            handles.append(PgQueueMessageHandle.from_meta_dict(pq["handle"]))
+        if handles:
+            self._consumer.ack(handles)
+
+    def close(self) -> None:
+        self.running = False
+        if self._consumer is not None:
+            self._consumer.close()
+            self._consumer = None

--- a/datahub-actions/src/datahub_actions/source/event_source_registry.py
+++ b/datahub-actions/src/datahub_actions/source/event_source_registry.py
@@ -17,9 +17,13 @@ from datahub_actions.plugin.source.acryl.datahub_cloud_event_source import (
     DataHubEventSource,
 )
 from datahub_actions.plugin.source.kafka.kafka_event_source import KafkaEventSource
+from datahub_actions.plugin.source.pgqueue.pg_queue_event_source import (
+    PgQueueEventSource,
+)
 from datahub_actions.source.event_source import EventSource
 
 event_source_registry = PluginRegistry[EventSource]()
 event_source_registry.register_from_entrypoint("datahub_actions.source.plugins")
 event_source_registry.register("kafka", KafkaEventSource)
+event_source_registry.register("pg_queue", PgQueueEventSource)
 event_source_registry.register("datahub-cloud", DataHubEventSource)

--- a/datahub-actions/tests/unit/plugin/source/pgqueue/test_pg_queue_event_source_ack_many.py
+++ b/datahub-actions/tests/unit/plugin/source/pgqueue/test_pg_queue_event_source_ack_many.py
@@ -1,0 +1,86 @@
+"""Batch ack behavior for pg_queue event source."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from datahub.pgqueue.repository import PgQueueMessageHandle
+from datahub_actions.event.event_envelope import EventEnvelope
+from datahub_actions.pipeline.pipeline_context import PipelineContext
+from datahub_actions.plugin.source.pgqueue.pg_queue_event_source import (
+    PgQueueEventSource,
+    PgQueueEventSourceConfig,
+)
+
+
+def _envelope_with_handle(handle_id: int) -> EventEnvelope:
+    handle = PgQueueMessageHandle(
+        id=handle_id,
+        enqueued_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        topic_id=1,
+        partition_id=0,
+        enqueue_seq=handle_id,
+    )
+    meta = {
+        "pg_queue": {
+            "topic": "MetadataChangeLog_Versioned_v1",
+            "partition": 0,
+            "enqueue_seq": handle_id,
+            "handle": handle.to_meta_dict(),
+        }
+    }
+    return EventEnvelope(event_type="test", event=MagicMock(), meta=meta)
+
+
+def _make_source() -> PgQueueEventSource:
+    cfg = PgQueueEventSourceConfig(
+        queue={
+            "host_port": "localhost:5432",
+            "database": "datahub",
+            "username": "datahub",
+            "password": "datahub",
+        }
+    )
+    ctx = PipelineContext(pipeline_name="test-pg-ack", graph=None)
+    with (
+        patch("datahub.pgqueue.consumer.SchemaRegistryClient"),
+        patch("datahub.pgqueue.consumer.create_pgqueue_connection"),
+    ):
+        return PgQueueEventSource(cfg, ctx)
+
+
+def test_ack_many_calls_consumer_ack_once_with_all_handles() -> None:
+    source = _make_source()
+    mock_consumer = MagicMock()
+    source._consumer = mock_consumer
+
+    ev1 = _envelope_with_handle(10)
+    ev2 = _envelope_with_handle(11)
+    source.ack_many([ev1, ev2], processed=True)
+
+    mock_consumer.ack.assert_called_once()
+    handles_arg = mock_consumer.ack.call_args[0][0]
+    assert len(handles_arg) == 2
+    assert handles_arg[0].id == 10
+    assert handles_arg[1].id == 11
+
+
+def test_ack_many_skipped_when_processed_false() -> None:
+    source = _make_source()
+    mock_consumer = MagicMock()
+    source._consumer = mock_consumer
+
+    source.ack_many([_envelope_with_handle(1)], processed=False)
+    mock_consumer.ack.assert_not_called()
+
+
+def test_ack_delegates_to_ack_many() -> None:
+    source = _make_source()
+    mock_consumer = MagicMock()
+    source._consumer = mock_consumer
+
+    ev = _envelope_with_handle(99)
+    source.ack(ev, processed=True)
+    mock_consumer.ack.assert_called_once()
+    assert len(mock_consumer.ack.call_args[0][0]) == 1

--- a/datahub-actions/tests/unit/plugin/source/pgqueue/test_pg_queue_event_source_config.py
+++ b/datahub-actions/tests/unit/plugin/source/pgqueue/test_pg_queue_event_source_config.py
@@ -1,0 +1,35 @@
+from datahub_actions.plugin.source.pgqueue.pg_queue_event_source import (
+    PgQueueEventSourceConfig,
+)
+
+
+def _make_config() -> PgQueueEventSourceConfig:
+    return PgQueueEventSourceConfig(
+        queue={
+            "host_port": "localhost:5432",
+            "database": "datahub",
+            "username": "datahub",
+            "password": "datahub",
+        }
+    )
+
+
+def test_build_consumer_config_uses_pipeline_name_as_group() -> None:
+    cfg = _make_config()
+    consumer_cfg = cfg.build_consumer_config("my-pipeline")
+    assert consumer_cfg.consumer_group == "my-pipeline"
+    assert consumer_cfg.queue.database == "datahub"
+    assert consumer_cfg.topic_routes["mcl"] == "MetadataChangeLog_Versioned_v1"
+
+
+def test_config_no_lock_owner_suffix() -> None:
+    """lock_owner_suffix was removed — config must not accept it."""
+    cfg = _make_config()
+    assert not hasattr(cfg, "lock_owner_suffix")
+
+
+def test_build_consumer_config_no_lock_owner_suffix() -> None:
+    """Built consumer config must not contain lock_owner_suffix."""
+    cfg = _make_config()
+    consumer_cfg = cfg.build_consumer_config("pipeline")
+    assert not hasattr(consumer_cfg, "lock_owner_suffix")

--- a/datahub-actions/tests/unit/plugin/source/pgqueue/test_pg_queue_event_source_events.py
+++ b/datahub-actions/tests/unit/plugin/source/pgqueue/test_pg_queue_event_source_events.py
@@ -1,0 +1,211 @@
+"""Tests for PgQueueEventSource.events() and _records_to_envelopes()."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Union
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub.metadata.schema_classes import (
+    MetadataChangeEventClass,
+    MetadataChangeLogClass,
+    MetadataChangeProposalClass,
+)
+from datahub.pgqueue.consumer import PgQueueConsumedRecord
+from datahub.pgqueue.repository import PgQueueMessageHandle, PgQueueReceivedMessage
+from datahub_actions.event.event_registry import (
+    ENTITY_CHANGE_EVENT_V1_TYPE,
+    METADATA_CHANGE_LOG_EVENT_V1_TYPE,
+    RELATIONSHIP_CHANGE_EVENT_V1_TYPE,
+)
+from datahub_actions.pipeline.pipeline_context import PipelineContext
+from datahub_actions.plugin.source.pgqueue.pg_queue_event_source import (
+    PgQueueEventSource,
+    PgQueueEventSourceConfig,
+)
+
+
+def _make_source() -> PgQueueEventSource:
+    cfg = PgQueueEventSourceConfig(
+        queue={
+            "host_port": "localhost:5432",
+            "database": "datahub",
+            "username": "datahub",
+            "password": "datahub",
+        }
+    )
+    ctx = PipelineContext(pipeline_name="test-events", graph=None)
+    with (
+        patch("datahub.pgqueue.consumer.SchemaRegistryClient"),
+        patch("datahub.pgqueue.consumer.create_pgqueue_connection"),
+    ):
+        return PgQueueEventSource(cfg, ctx)
+
+
+def _make_handle(msg_id: int = 1) -> PgQueueMessageHandle:
+    return PgQueueMessageHandle(
+        id=msg_id,
+        enqueued_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        topic_id=1,
+        partition_id=0,
+        enqueue_seq=msg_id,
+    )
+
+
+def _make_raw(handle: PgQueueMessageHandle) -> PgQueueReceivedMessage:
+    return PgQueueReceivedMessage(
+        handle=handle,
+        priority=0,
+        payload=b"",
+        content_type=None,
+        payload_compression=0,
+        headers=(),
+        routing_key="test",
+        lock_owner="test-owner",
+    )
+
+
+RecordType = Union[
+    MetadataChangeEventClass,
+    MetadataChangeProposalClass,
+    MetadataChangeLogClass,
+    Dict[str, Any],
+]
+
+
+def _make_consumed_record(
+    record: RecordType,
+    topic_name: str,
+    handle: PgQueueMessageHandle,
+    route_key: str = "mcl",
+) -> PgQueueConsumedRecord:
+    return PgQueueConsumedRecord(
+        route_key=route_key,
+        topic_name=topic_name,
+        raw=_make_raw(handle),
+        record=record,
+    )
+
+
+def test_events_raises_when_consumer_is_none() -> None:
+    source = _make_source()
+    source._consumer = None
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        next(iter(source.events()))
+
+
+def test_records_to_envelopes_mcl_yields_mcl_event() -> None:
+    source = _make_source()
+    mcl = MetadataChangeLogClass(
+        entityType="dataset",
+        changeType="UPSERT",
+        aspectName="status",
+    )
+    rec = _make_consumed_record(
+        record=mcl,
+        topic_name="MetadataChangeLog_Versioned_v1",
+        handle=_make_handle(),
+    )
+
+    envelopes = list(source._records_to_envelopes(rec))
+
+    assert len(envelopes) == 1
+    assert envelopes[0].event_type == METADATA_CHANGE_LOG_EVENT_V1_TYPE
+
+
+def test_records_to_envelopes_entity_change_event() -> None:
+    source = _make_source()
+
+    ece_payload = {
+        "value": (
+            '{"entityUrn":"urn:li:dataset:1",'
+            '"entityType":"dataset",'
+            '"category":"TAG",'
+            '"operation":"ADD",'
+            '"modifier":"urn:li:tag:pii",'
+            '"parameters":{},'
+            '"auditStamp":{"time":1700000000000,"actor":"urn:li:corpuser:datahub"},'
+            '"version":0}'
+        ),
+        "contentType": "JSON",
+    }
+    platform_event = {
+        "name": "entityChangeEvent",
+        "payload": ece_payload,
+    }
+    rec = _make_consumed_record(
+        record=platform_event,
+        topic_name="PlatformEvent_v1",
+        handle=_make_handle(),
+        route_key="pe",
+    )
+
+    envelopes = list(source._records_to_envelopes(rec))
+
+    assert len(envelopes) == 1
+    assert envelopes[0].event_type == ENTITY_CHANGE_EVENT_V1_TYPE
+
+
+def test_records_to_envelopes_relationship_change_event() -> None:
+    source = _make_source()
+
+    rce_payload = {
+        "value": (
+            '{"sourceUrn":"urn:li:dataset:1",'
+            '"destinationUrn":"urn:li:dataset:2",'
+            '"relationshipType":"DownstreamOf",'
+            '"category":"TAG",'
+            '"operation":"ADD",'
+            '"parameters":{},'
+            '"auditStamp":{"time":1700000000000,"actor":"urn:li:corpuser:datahub"}}'
+        ),
+        "contentType": "JSON",
+    }
+    platform_event = {
+        "name": "relationshipChangeEvent",
+        "payload": rce_payload,
+    }
+    rec = _make_consumed_record(
+        record=platform_event,
+        topic_name="PlatformEvent_v1",
+        handle=_make_handle(),
+        route_key="pe",
+    )
+
+    envelopes = list(source._records_to_envelopes(rec))
+
+    assert len(envelopes) == 1
+    assert envelopes[0].event_type == RELATIONSHIP_CHANGE_EVENT_V1_TYPE
+
+
+def test_records_to_envelopes_unexpected_type_yields_nothing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    source = _make_source()
+    mcp = MetadataChangeProposalClass(entityType="dataset", changeType="UPSERT")
+    rec = _make_consumed_record(
+        record=mcp,
+        topic_name="Unknown_v1",
+        handle=_make_handle(),
+    )
+
+    envelopes = list(source._records_to_envelopes(rec))
+
+    assert envelopes == []
+    assert "Unexpected pgQueue payload type" in caplog.text
+
+
+def test_close_sets_running_false_and_closes_consumer() -> None:
+    source = _make_source()
+    mock_consumer = MagicMock()
+    source._consumer = mock_consumer
+    source.running = True
+
+    source.close()
+
+    assert source.running is False
+    mock_consumer.close.assert_called_once()
+    assert source._consumer is None

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolver.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.structuredproperties;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.applyProposalUiSource;
 import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.buildMetadataChangeProposalWithUrn;
 import static com.linkedin.metadata.Constants.*;
 
@@ -169,7 +170,7 @@ public class CreateStructuredPropertyResolver
     builder.setCreated(context.getOperationContext().getAuditStamp());
     builder.setLastModified(context.getOperationContext().getAuditStamp());
 
-    return builder.build();
+    return applyProposalUiSource(builder.build());
   }
 
   private void buildTypeQualifier(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpsertStructuredPropertiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpsertStructuredPropertiesResolver.java
@@ -21,6 +21,7 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.entity.AspectUtils;
 import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.structured.PrimitivePropertyValue;
 import com.linkedin.structured.PrimitivePropertyValueArray;
 import com.linkedin.structured.StructuredProperties;
 import com.linkedin.structured.StructuredPropertyValueAssignment;
@@ -33,10 +34,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class UpsertStructuredPropertiesResolver
     implements DataFetcher<
         CompletableFuture<com.linkedin.datahub.graphql.generated.StructuredProperties>> {
@@ -82,9 +86,28 @@ public class UpsertStructuredPropertiesResolver
                   String.format("Asset with provided urn %s does not exist", assetUrn));
             }
 
+            final OperationContext opContext = context.getOperationContext();
+
             // get or default the structured properties aspect
             StructuredProperties structuredProperties =
-                getStructuredProperties(context.getOperationContext(), assetUrn);
+                getStructuredProperties(opContext, assetUrn);
+
+            final int assignmentCountBeforeFilter =
+                structuredProperties.hasProperties()
+                    ? structuredProperties.getProperties().size()
+                    : 0;
+
+            // Drop assignments whose property definition was hard-deleted so a full-aspect upsert
+            // does not fail validation on orphaned values.
+            structuredProperties =
+                filterHardDeletedPropertyAssignments(opContext, structuredProperties);
+
+            final boolean orphansRemoved =
+                assignmentCountBeforeFilter > structuredProperties.getProperties().size();
+
+            if (!requiresIngest(orphansRemoved, structuredProperties, updateMap)) {
+              return StructuredPropertiesMapper.map(context, structuredProperties, assetUrn);
+            }
 
             // update the existing properties based on new value
             StructuredPropertyValueAssignmentArray properties =
@@ -95,13 +118,11 @@ public class UpsertStructuredPropertiesResolver
 
             structuredProperties.setProperties(properties);
 
-            // ingest change proposal
             final MetadataChangeProposal structuredPropertiesProposal =
                 AspectUtils.buildMetadataChangeProposal(
                     assetUrn, STRUCTURED_PROPERTIES_ASPECT_NAME, structuredProperties);
 
-            _entityClient.ingestProposal(
-                context.getOperationContext(), structuredPropertiesProposal, false);
+            _entityClient.ingestProposal(opContext, structuredPropertiesProposal, false);
 
             return StructuredPropertiesMapper.map(context, structuredProperties, assetUrn);
           } catch (Exception e) {
@@ -111,6 +132,95 @@ public class UpsertStructuredPropertiesResolver
         },
         this.getClass().getSimpleName(),
         "get");
+  }
+
+  /** Removes value assignments whose structured property entity no longer exists (hard-deleted). */
+  @Nonnull
+  private StructuredProperties filterHardDeletedPropertyAssignments(
+      @Nonnull OperationContext opContext, @Nonnull StructuredProperties structuredProperties)
+      throws Exception {
+    if (!structuredProperties.hasProperties()) {
+      return structuredProperties;
+    }
+
+    Set<Urn> propertyUrns =
+        structuredProperties.getProperties().stream()
+            .map(StructuredPropertyValueAssignment::getPropertyUrn)
+            .collect(Collectors.toSet());
+
+    if (propertyUrns.isEmpty()) {
+      return structuredProperties;
+    }
+
+    Set<Urn> existingPropertyUrns = _entityClient.filterExistingUrns(opContext, propertyUrns);
+
+    StructuredPropertyValueAssignmentArray filtered = new StructuredPropertyValueAssignmentArray();
+    for (StructuredPropertyValueAssignment assignment : structuredProperties.getProperties()) {
+      Urn propertyUrn = assignment.getPropertyUrn();
+      if (existingPropertyUrns.contains(propertyUrn)) {
+        filtered.add(assignment);
+      } else {
+        log.debug(
+            "Dropping structured property assignment for hard-deleted definition {}", propertyUrn);
+      }
+    }
+    return structuredProperties.setProperties(filtered);
+  }
+
+  private static boolean requiresIngest(
+      boolean orphansRemoved,
+      @Nonnull StructuredProperties afterFilter,
+      @Nonnull Map<String, List<PropertyValueInput>> updateMap) {
+    if (orphansRemoved) {
+      return true;
+    }
+    if (!afterFilter.hasProperties()) {
+      return !updateMap.isEmpty();
+    }
+
+    Set<String> existingPropertyUrns =
+        afterFilter.getProperties().stream()
+            .map(assignment -> assignment.getPropertyUrn().toString())
+            .collect(Collectors.toSet());
+
+    if (updateMap.keySet().stream().anyMatch(key -> !existingPropertyUrns.contains(key))) {
+      return true;
+    }
+
+    for (StructuredPropertyValueAssignment assignment : afterFilter.getProperties()) {
+      String propertyUrnString = assignment.getPropertyUrn().toString();
+      if (updateMap.containsKey(propertyUrnString)
+          && requiresUpsert(assignment, updateMap.get(propertyUrnString))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns true when the assignment must be written: value mismatch or attribution is present
+   * (upsert clears attribution on update).
+   */
+  private static boolean requiresUpsert(
+      @Nonnull StructuredPropertyValueAssignment existing,
+      @Nonnull List<PropertyValueInput> desiredValues) {
+    if (existing.hasAttribution()) {
+      return true;
+    }
+    return !existing.getValues().equals(toPrimitiveValues(desiredValues));
+  }
+
+  private static PrimitivePropertyValueArray toPrimitiveValues(
+      @Nonnull List<PropertyValueInput> desiredValues) {
+    final PrimitivePropertyValueArray values = new PrimitivePropertyValueArray();
+    for (PropertyValueInput valueInput : desiredValues) {
+      final PrimitivePropertyValue primitiveValue =
+          StructuredPropertyUtils.mapPropertyValueInput(valueInput);
+      if (primitiveValue != null) {
+        values.add(primitiveValue);
+      }
+    }
+    return values;
   }
 
   private StructuredProperties getStructuredProperties(
@@ -123,7 +233,9 @@ public class UpsertStructuredPropertiesResolver
             ImmutableSet.of(STRUCTURED_PROPERTIES_ASPECT_NAME));
     StructuredProperties structuredProperties = new StructuredProperties();
     structuredProperties.setProperties(new StructuredPropertyValueAssignmentArray());
-    if (response != null && response.getAspects().containsKey(STRUCTURED_PROPERTIES_ASPECT_NAME)) {
+    if (response != null
+        && response.getAspects() != null
+        && response.getAspects().containsKey(STRUCTURED_PROPERTIES_ASPECT_NAME)) {
       structuredProperties =
           new StructuredProperties(
               response.getAspects().get(STRUCTURED_PROPERTIES_ASPECT_NAME).getValue().data());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolverTest.java
@@ -2,6 +2,9 @@ package com.linkedin.datahub.graphql.resolvers.structuredproperties;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContext;
+import static com.linkedin.metadata.Constants.APP_SOURCE;
+import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.UI_SOURCE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.testng.Assert.*;
 import static org.testng.Assert.assertFalse;
@@ -172,6 +175,28 @@ public class CreateStructuredPropertyResolverTest {
     // Validate ingest is not called
     Mockito.verify(mockEntityClient, Mockito.times(0))
         .batchIngestProposals(any(), Mockito.anyList(), Mockito.eq(false));
+  }
+
+  @Test
+  public void testCreatePropertyDefinitionMcpHasUiSource() throws Exception {
+    EntityClient mockEntityClient = initMockEntityClient(true);
+    CreateStructuredPropertyResolver resolver =
+        new CreateStructuredPropertyResolver(mockEntityClient);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    ArgumentCaptor<List<MetadataChangeProposal>> mcpCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(mockEntityClient, Mockito.times(1))
+        .batchIngestProposals(any(), mcpCaptor.capture(), Mockito.eq(false));
+
+    MetadataChangeProposal definitionMcp = mcpCaptor.getValue().get(0);
+    assertEquals(definitionMcp.getAspectName(), STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME);
+    assertEquals(definitionMcp.getSystemMetadata().getProperties().get(APP_SOURCE), UI_SOURCE);
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpsertStructuredPropertiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpsertStructuredPropertiesResolverTest.java
@@ -3,7 +3,9 @@ package com.linkedin.datahub.graphql.resolvers.structuredproperties;
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTIES_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertThrows;
 
 import com.linkedin.common.MetadataAttribution;
@@ -29,7 +31,10 @@ import graphql.com.google.common.collect.ImmutableList;
 import graphql.com.google.common.collect.ImmutableSet;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -39,6 +44,7 @@ public class UpsertStructuredPropertiesResolverTest {
       "urn:li:dataset:(urn:li:dataPlatform:hive,name,PROD)";
   private static final String PROPERTY_URN_1 = "urn:li:structuredProperty:test1";
   private static final String PROPERTY_URN_2 = "urn:li:structuredProperty:test2";
+  private static final String HARD_DELETED_PROPERTY_URN = "urn:li:structuredProperty:deleted";
 
   private static final StructuredPropertyInputParams PROP_INPUT_1 =
       new StructuredPropertyInputParams(
@@ -233,6 +239,85 @@ public class UpsertStructuredPropertiesResolverTest {
   }
 
   @Test
+  public void testNoOpWhenValuesUnchanged() throws Exception {
+    StructuredPropertyValueAssignmentArray initialProperties =
+        new StructuredPropertyValueAssignmentArray();
+    initialProperties.add(
+        new StructuredPropertyValueAssignment()
+            .setPropertyUrn(UrnUtils.getUrn(PROPERTY_URN_1))
+            .setValues(new PrimitivePropertyValueArray(PrimitivePropertyValue.create("test1"))));
+    initialProperties.add(
+        new StructuredPropertyValueAssignment()
+            .setPropertyUrn(UrnUtils.getUrn(PROPERTY_URN_2))
+            .setValues(new PrimitivePropertyValueArray(PrimitivePropertyValue.create("test2"))));
+
+    EntityClient mockEntityClient = initMockEntityClient(true, initialProperties);
+    UpsertStructuredPropertiesResolver resolver =
+        new UpsertStructuredPropertiesResolver(mockEntityClient);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    Mockito.verify(mockEntityClient, Mockito.times(0))
+        .ingestProposal(any(), Mockito.any(MetadataChangeProposal.class), Mockito.eq(false));
+    Mockito.verify(mockEntityClient, times(1))
+        .filterExistingUrns(any(OperationContext.class), any(Collection.class));
+  }
+
+  @Test
+  public void testFiltersHardDeletedPropertyAssignments() throws Exception {
+    StructuredPropertyValueAssignmentArray initialProperties =
+        new StructuredPropertyValueAssignmentArray();
+    initialProperties.add(
+        new StructuredPropertyValueAssignment()
+            .setPropertyUrn(UrnUtils.getUrn(HARD_DELETED_PROPERTY_URN))
+            .setValues(new PrimitivePropertyValueArray(PrimitivePropertyValue.create("orphan"))));
+    initialProperties.add(
+        new StructuredPropertyValueAssignment()
+            .setPropertyUrn(UrnUtils.getUrn(PROPERTY_URN_1))
+            .setValues(new PrimitivePropertyValueArray(PrimitivePropertyValue.create("hello"))));
+
+    EntityClient mockEntityClient = initMockEntityClient(true, initialProperties);
+    Mockito.when(
+            mockEntityClient.filterExistingUrns(any(OperationContext.class), any(Collection.class)))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Collection<Urn> urns = invocation.getArgument(1);
+              return urns.stream()
+                  .filter(urn -> !urn.equals(UrnUtils.getUrn(HARD_DELETED_PROPERTY_URN)))
+                  .collect(Collectors.toSet());
+            });
+
+    UpsertStructuredPropertiesResolver resolver =
+        new UpsertStructuredPropertiesResolver(mockEntityClient);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    com.linkedin.datahub.graphql.generated.StructuredProperties result =
+        resolver.get(mockEnv).get();
+
+    assertEquals(result.getProperties().size(), 2);
+    assertFalse(
+        result.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getStructuredProperty().getUrn().equals(HARD_DELETED_PROPERTY_URN)));
+
+    Mockito.verify(mockEntityClient, Mockito.times(1))
+        .ingestProposal(any(), Mockito.any(MetadataChangeProposal.class), Mockito.eq(false));
+    Mockito.verify(mockEntityClient, times(1))
+        .filterExistingUrns(any(OperationContext.class), any(Collection.class));
+  }
+
+  @Test
   public void testThrowsError() throws Exception {
     EntityClient mockEntityClient = initMockEntityClient(false, null);
     UpsertStructuredPropertiesResolver resolver =
@@ -260,6 +345,13 @@ public class UpsertStructuredPropertiesResolverTest {
     Mockito.when(client.exists(any(OperationContext.class), Mockito.eq(assetUrn), any()))
         .thenReturn(true);
     Mockito.when(client.exists(any(OperationContext.class), Mockito.eq(assetUrn))).thenReturn(true);
+    Mockito.when(client.filterExistingUrns(any(OperationContext.class), any(Collection.class)))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Collection<Urn> urns = invocation.getArgument(1);
+              return new HashSet<>(urns);
+            });
 
     if (!shouldSucceed) {
       Mockito.doThrow(new RuntimeException())

--- a/metadata-ingestion/constraints.txt
+++ b/metadata-ingestion/constraints.txt
@@ -295,7 +295,9 @@ coverage==7.13.4
     #   acryl-datahub
     #   pytest-cov
 cramjam==2.11.0
-    # via python-snappy
+    # via
+    #   acryl-datahub
+    #   python-snappy
 croniter==6.0.0
     # via acryl-datahub-cloud
 cryptography==46.0.7

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "click-default-group<2.0.0",
     "click-spinner<0.2.0",
     "click>=7.1.2,!=8.2.0,<9.0.0",
+    "cramjam>=2.8.0,<3.0.0",
     "Deprecated<2.0.0",
     "docker<8.0.0",
     "expandvars>=0.6.5,<2.0.0",
@@ -377,6 +378,15 @@ datahub-lite = [
     "duckdb>=1.0.0,<2.0.0",
     "fastapi<0.129.0",
     "uvicorn<0.41.0",
+]
+
+datahub-pg-queue = [
+    "boto3>=1.35.0,<2.0.0",
+    "botocore!=1.23.0,<2.0.0",
+    "confluent_kafka[schemaregistry,avro]>=1.9.0,!= 2.8.1,<3.0.0",
+    "fastavro>=1.2.0,<2.0.0",
+    "psycopg2-binary<3.0.0",
+    "urllib3>=1.26,<3.0",
 ]
 
 datahub-rest = [
@@ -1624,6 +1634,7 @@ dev = [
     "clickhouse-sqlalchemy>=0.2.0,<0.2.5",
     "confluent_kafka[schemaregistry,avro]>=2.10.1,<2.13.0",
     "coverage>=5.1,<8.0.0",
+    "cramjam>=2.8.0,<3.0.0",
     "cryptography>=46.0.7,<47.0.0",
     "dask[dataframe]<2024.7.0",
     "databricks-dbapi<0.7.0",
@@ -1818,6 +1829,7 @@ docs = [
     "clickhouse-sqlalchemy>=0.2.0,<0.2.5",
     "confluent_kafka[schemaregistry,avro]>=2.10.1,<2.13.0",
     "coverage>=5.1,<8.0.0",
+    "cramjam>=2.8.0,<3.0.0",
     "cryptography>=46.0.7,<47.0.0",
     "dask[dataframe]<2024.7.0",
     "databricks-dbapi<0.7.0",
@@ -2240,6 +2252,7 @@ file = "datahub.ingestion.sink.file:FileSink"
 console = "datahub.ingestion.sink.console:ConsoleSink"
 blackhole = "datahub.ingestion.sink.blackhole:BlackHoleSink"
 datahub-kafka = "datahub.ingestion.sink.datahub_kafka:DatahubKafkaSink"
+datahub-pg-queue = "datahub.ingestion.sink.datahub_pg_queue:DatahubPgQueueSink"
 datahub-rest = "datahub.ingestion.sink.datahub_rest:DatahubRestSink"
 datahub-lite = "datahub.ingestion.sink.datahub_lite:DataHubLiteSink"
 

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -79,6 +79,8 @@ framework_common = {
     # From ruamel-yaml 0.19.0 (Dec 31, 2025) it requires ruamel-yaml-clibz as a mandatory dependency
     # which is not available as wheel.
     "ruamel.yaml<0.19.0",
+    # Snappy-compatible codec for pgQueue payload decompression (Java Snappy); not Kafka-specific.
+    "cramjam>=2.8.0,<3.0.0",
 }
 
 rest_common = {
@@ -533,6 +535,12 @@ plugins: Dict[str, Set[str]] = {
         "confluent_kafka[schemaregistry,avro]>=1.9.0,!= 2.8.1,<3.0.0",
         "fastavro>=1.2.0,<2.0.0",
     },
+    "datahub-pg-queue": {
+        "confluent_kafka[schemaregistry,avro]>=1.9.0,!= 2.8.1,<3.0.0",
+        "fastavro>=1.2.0,<2.0.0",
+        "psycopg2-binary<3.0.0",
+    }
+    | aws_common,
     "datahub-rest": rest_common,
     # 3.13.1 minimum for Airflow 2.7.3+ constraint compatibility; Docker/constraints enforce >=3.20.3 where needed.
     "sync-file-emitter": {"filelock>=3.13.1,<4.0.0"},
@@ -1222,6 +1230,7 @@ entry_points = {
         "console = datahub.ingestion.sink.console:ConsoleSink",
         "blackhole = datahub.ingestion.sink.blackhole:BlackHoleSink",
         "datahub-kafka = datahub.ingestion.sink.datahub_kafka:DatahubKafkaSink",
+        "datahub-pg-queue = datahub.ingestion.sink.datahub_pg_queue:DatahubPgQueueSink",
         "datahub-rest = datahub.ingestion.sink.datahub_rest:DatahubRestSink",
         "datahub-lite = datahub.ingestion.sink.datahub_lite:DataHubLiteSink",
     ],

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_pg_queue.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_pg_queue.py
@@ -1,0 +1,88 @@
+"""Sink that writes MCP/MCE metadata to PostgreSQL pgQueue (Kafka-compatible payloads)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Union
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.emitter.mcp_builder import mcps_from_mce
+from datahub.ingestion.api.common import RecordEnvelope, WorkUnit
+from datahub.ingestion.api.sink import Sink, SinkReport, WriteCallback
+from datahub.ingestion.sink.datahub_kafka import (
+    _AggregatingKafkaCallback,
+    _KafkaCallback,
+)
+from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
+    MetadataChangeEvent,
+    MetadataChangeProposal,
+)
+from datahub.pgqueue.config import PgQueueEmitterConfig
+from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+logger = logging.getLogger(__name__)
+
+
+class PgQueueSinkConfig(PgQueueEmitterConfig):
+    """Recipe configuration mirroring ``KafkaEmitterConfig`` fields plus pgQueue connectivity."""
+
+    pass
+
+
+class DatahubPgQueueSink(Sink[PgQueueSinkConfig, SinkReport]):
+    emitter: DatahubPgQueueEmitter
+
+    def __post_init__(self) -> None:
+        self.emitter = DatahubPgQueueEmitter(self.config)
+
+    def handle_work_unit_start(self, workunit: WorkUnit) -> None:
+        pass
+
+    def handle_work_unit_end(self, workunit: WorkUnit) -> None:
+        self.emitter.flush()
+
+    def write_record_async(
+        self,
+        record_envelope: RecordEnvelope[
+            Union[
+                MetadataChangeEvent,
+                MetadataChangeProposal,
+                MetadataChangeProposalWrapper,
+            ]
+        ],
+        write_callback: WriteCallback,
+    ) -> None:
+        queue_callback = _KafkaCallback(self.report, record_envelope, write_callback)
+        try:
+            record = record_envelope.record
+
+            if isinstance(record, MetadataChangeEvent):
+                logger.debug(
+                    "Unpacking MCE for %s into individual MCPs",
+                    record.proposedSnapshot.urn,
+                )
+                mcps = list(mcps_from_mce(record))
+                if not mcps:
+                    logger.warning(
+                        "MCE for %s produced zero MCPs",
+                        record.proposedSnapshot.urn,
+                    )
+                    write_callback.on_success(
+                        record_envelope, {"msg": "MCE had zero aspects"}
+                    )
+                    return
+
+                agg_callback = _AggregatingKafkaCallback(
+                    total=len(mcps), inner=queue_callback
+                )
+                self.emitter.emit_batch(mcps, callback=agg_callback.kafka_callback)
+            else:
+                self.emitter.emit(record, callback=queue_callback.kafka_callback)
+        except Exception as err:
+            queue_callback.report_emit_failure(err)
+
+    def close(self) -> None:
+        try:
+            self.emitter.close()
+        finally:
+            super().close()

--- a/metadata-ingestion/src/datahub/pgqueue/__init__.py
+++ b/metadata-ingestion/src/datahub/pgqueue/__init__.py
@@ -1,0 +1,56 @@
+"""PostgreSQL-backed DataHub queue client (pgQueue DDL).
+
+The psycopg2-facing modules (:mod:`datahub.pgqueue.repository`, :mod:`datahub.pgqueue.connection`)
+do not import catalog ingestion sources. Emitter/consumer classes are loaded lazily so importing
+those modules—or ``datahub.pgqueue``—does not pull Schema Registry / Avro helpers unless you use
+the Kafka-compatible client entrypoints.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from datahub.pgqueue.config import (
+    PayloadRouteKind,
+    PgQueueAuthMode,
+    PgQueueConnectionConfig,
+    PgQueueConsumerConfig,
+    PgQueueEmitterConfig,
+    PgQueueTopicDefaultsConfig,
+)
+from datahub.pgqueue.repository import EnqueueBatchItem, PgQueueMessageHandle
+
+__all__ = [
+    "EnqueueBatchItem",
+    "PgQueueMessageHandle",
+    "PgQueueConsumedRecord",
+    "build_pg_queue_event_meta",
+    "DatahubPgQueueConsumer",
+    "DatahubPgQueueEmitter",
+    "PgQueueAuthMode",
+    "PgQueueConnectionConfig",
+    "PayloadRouteKind",
+    "PgQueueConsumerConfig",
+    "PgQueueEmitterConfig",
+    "PgQueueTopicDefaultsConfig",
+]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "DatahubPgQueueConsumer":
+        from datahub.pgqueue.consumer import DatahubPgQueueConsumer
+
+        return DatahubPgQueueConsumer
+    if name == "PgQueueConsumedRecord":
+        from datahub.pgqueue.consumer import PgQueueConsumedRecord
+
+        return PgQueueConsumedRecord
+    if name == "build_pg_queue_event_meta":
+        from datahub.pgqueue.consumer import build_pg_queue_event_meta
+
+        return build_pg_queue_event_meta
+    if name == "DatahubPgQueueEmitter":
+        from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+        return DatahubPgQueueEmitter
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/metadata-ingestion/src/datahub/pgqueue/compression.py
+++ b/metadata-ingestion/src/datahub/pgqueue/compression.py
@@ -1,0 +1,41 @@
+"""Application-layer pgQueue payload codecs (maps to ``message.payload_compression``)."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class PgQueuePayloadCompression(IntEnum):
+    NONE = 0
+    SNAPPY = 1
+
+
+def from_wire(code: int) -> PgQueuePayloadCompression:
+    if code == 0:
+        return PgQueuePayloadCompression.NONE
+    if code == 1:
+        return PgQueuePayloadCompression.SNAPPY
+    raise ValueError(
+        f"Unsupported pgQueue payload_compression code: {code} (reserved or not implemented)"
+    )
+
+
+def encode_inner(inner: bytes, mode: PgQueuePayloadCompression) -> bytes:
+    if mode == PgQueuePayloadCompression.NONE:
+        return inner
+    if mode == PgQueuePayloadCompression.SNAPPY:
+        from cramjam import snappy
+
+        # Raw block format — matches org.xerial.snappy.Snappy on the Java producer.
+        return bytes(snappy.compress_raw(inner))
+    raise ValueError(f"Unhandled pgQueue payload compression mode: {mode}")
+
+
+def decode_stored(stored: bytes, mode: PgQueuePayloadCompression) -> bytes:
+    if mode == PgQueuePayloadCompression.NONE:
+        return stored
+    if mode == PgQueuePayloadCompression.SNAPPY:
+        from cramjam import snappy
+
+        return bytes(snappy.decompress_raw(stored))
+    raise ValueError(f"Unhandled pgQueue payload compression mode: {mode}")

--- a/metadata-ingestion/src/datahub/pgqueue/config.py
+++ b/metadata-ingestion/src/datahub/pgqueue/config.py
@@ -1,0 +1,286 @@
+"""Configuration models for PostgreSQL queue connectivity and defaults."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import Field, field_validator, model_validator
+from pydantic.types import SecretStr
+
+from datahub.configuration.common import ConfigModel
+from datahub.configuration.kafka import _get_schema_registry_url
+from datahub.configuration.validate_host_port import validate_host_port
+from datahub.emitter.kafka_emitter import (
+    DEFAULT_MCE_KAFKA_TOPIC,
+    DEFAULT_MCP_KAFKA_TOPIC,
+    MCE_KEY,
+    MCP_KEY,
+)
+from datahub.pgqueue.sql import validate_pg_identifier
+from datahub.utilities.str_enum import StrEnum
+
+PayloadRouteKind = Literal["mcp", "mce", "mcl", "pe"]
+
+logger = logging.getLogger(__name__)
+
+
+def _default_payload_kinds() -> Dict[str, PayloadRouteKind]:
+    return {MCE_KEY: "mce", MCP_KEY: "mcp"}
+
+
+class PgQueueAuthMode(StrEnum):
+    """Authentication mode for PostgreSQL (matches Postgres source semantics)."""
+
+    PASSWORD = "PASSWORD"
+    AWS_IAM = "AWS_IAM"
+
+
+class PgQueueTopicPartialConfig(ConfigModel):
+    """Optional overrides keyed by topic name (extends topic_defaults for that topic)."""
+
+    partition_count: Optional[int] = Field(default=None, ge=1, le=4096)
+    priority_bands: Optional[str] = Field(
+        default=None,
+        description="JSON: priority band ranges and weights for weighted fair queuing.",
+    )
+    retention_max_age_seconds: Optional[int] = Field(default=None, ge=0)
+    max_rows_per_topic: Optional[int] = Field(default=None, ge=0)
+    max_total_payload_bytes_per_topic: Optional[int] = Field(default=None, ge=0)
+
+
+class PgQueueTopicDefaultsConfig(ConfigModel):
+    """Defaults applied when auto-creating a logical topic row (GMS-aligned names)."""
+
+    partition_count: int = Field(
+        default=2,
+        ge=1,
+        le=4096,
+        description="Number of partitions for new topics (postgres.pgQueue.topicDefaults.partitionCount).",
+    )
+    visibility_timeout_seconds: int = Field(
+        default=600,
+        ge=1,
+        le=604800,
+        description="Consumer lock duration in seconds after dequeue.",
+    )
+    priority_bands: str = Field(
+        default='[{"range":[0,3],"weight":70},{"range":[4,6],"weight":20},{"range":[7,9],"weight":10}]',
+        description="JSON: priority band ranges and weights for weighted fair queuing.",
+    )
+    retention_max_age_seconds: int = Field(
+        default=604800,
+        ge=0,
+        description="Retention age for rows (0 = disabled at topic level).",
+    )
+    max_rows_per_topic: int = Field(
+        default=0,
+        ge=0,
+        description="Max rows per topic (0 = unlimited).",
+    )
+    max_total_payload_bytes_per_topic: int = Field(
+        default=0,
+        ge=0,
+        description="Max total payload bytes per topic (0 = unlimited).",
+    )
+    default_content_type_mime: str = Field(
+        default="application/avro",
+        description=(
+            "MIME for topic.default_content_type_id (lookup in *_content_type); aligns with "
+            "postgres.pgQueue.topicDefaults.defaultContentTypeMime / DATAHUB_PGQUEUE_TOPIC_DEFAULT_CONTENT_TYPE_MIME."
+        ),
+    )
+
+
+class PgQueueConnectionConfig(ConfigModel):
+    """JDBC-like connectivity to the PostgreSQL database hosting pgQueue tables."""
+
+    host_port: str = Field(description="Host or host:port for PostgreSQL.")
+    database: str = Field(description="Database name.")
+    username: str = Field(
+        description="PostgreSQL user (IAM DB user when using AWS_IAM)."
+    )
+
+    password: Optional[SecretStr] = Field(
+        default=None,
+        description="Password when auth_mode is PASSWORD.",
+    )
+
+    sslmode: str = Field(
+        default="prefer",
+        description="libpq sslmode (require recommended for RDS IAM).",
+    )
+
+    auth_mode: PgQueueAuthMode = Field(
+        default=PgQueueAuthMode.PASSWORD,
+        description="PASSWORD or AWS_IAM (RDS IAM token as password).",
+    )
+
+    aws_config: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "AWS SDK settings when auth_mode is AWS_IAM. Same keys as "
+            "datahub.ingestion.source.aws.aws_common.AwsConnectionConfig; validated when "
+            "opening a connection (see datahub.pgqueue.connection)."
+        ),
+    )
+
+    queue_schema: str = Field(
+        default="queue",
+        description="PostgreSQL schema containing pgQueue tables (DATAHUB_PGQUEUE_SCHEMA).",
+    )
+
+    table_prefix: str = Field(
+        default="metadata_queue",
+        description="Table prefix: {prefix}_topic, {prefix}_message, ...",
+    )
+
+    topic_defaults: PgQueueTopicDefaultsConfig = Field(
+        default_factory=PgQueueTopicDefaultsConfig,
+        description="Applied when inserting a missing logical topic.",
+    )
+
+    topic_overrides: Dict[str, PgQueueTopicPartialConfig] = Field(
+        default_factory=dict,
+        description=(
+            "Per-topic row settings keyed by topic name (e.g. MetadataChangeLog_Timeseries_v1); "
+            "merges onto topic_defaults for emit/enqueue (parity with postgres.pgQueue.topics in GMS)."
+        ),
+    )
+
+    connect_timeout_seconds: int = Field(default=60, ge=1, le=3600)
+
+    def merged_topic_defaults_for(self, topic_name: str) -> PgQueueTopicDefaultsConfig:
+        """Defaults for topic_name with optional topic_overrides applied."""
+        base = self.topic_defaults.model_copy(deep=True)
+        partial = self.topic_overrides.get(topic_name)
+        if partial is None:
+            return base
+        if partial.partition_count is not None:
+            base.partition_count = partial.partition_count
+        if partial.priority_bands is not None:
+            base.priority_bands = partial.priority_bands
+        if partial.retention_max_age_seconds is not None:
+            base.retention_max_age_seconds = partial.retention_max_age_seconds
+        if partial.max_rows_per_topic is not None:
+            base.max_rows_per_topic = partial.max_rows_per_topic
+        if partial.max_total_payload_bytes_per_topic is not None:
+            base.max_total_payload_bytes_per_topic = (
+                partial.max_total_payload_bytes_per_topic
+            )
+        return base
+
+    @field_validator("host_port", mode="after")
+    @classmethod
+    def host_port_validate(cls, val: str) -> str:
+        validate_host_port(val)
+        return val
+
+    @field_validator("queue_schema", "table_prefix", mode="after")
+    @classmethod
+    def validate_sql_identifiers(cls, val: str) -> str:
+        validate_pg_identifier(val, "queue_schema/table_prefix")
+        return val
+
+    @model_validator(mode="after")
+    def validate_auth(self) -> PgQueueConnectionConfig:
+        if self.auth_mode == PgQueueAuthMode.PASSWORD:
+            if not self.password:
+                raise ValueError("password is required when auth_mode is PASSWORD")
+        elif self.auth_mode == PgQueueAuthMode.AWS_IAM:
+            if ":" not in self.host_port:
+                raise ValueError(
+                    "host_port must include explicit port for AWS_IAM (e.g. host:5432)."
+                )
+        return self
+
+
+class PgQueueEmitterConfig(ConfigModel):
+    """Produce MCP/MCE records into pgQueue using Kafka-compatible Avro payloads."""
+
+    queue: PgQueueConnectionConfig
+
+    schema_registry_url: str = Field(
+        default_factory=_get_schema_registry_url,
+        description="Schema Registry URL (same as Kafka emitter).",
+    )
+
+    schema_registry_config: Dict[str, object] = Field(
+        default_factory=dict,
+        description="Extra Schema Registry client options.",
+    )
+
+    topic_routes: Dict[str, str] = Field(
+        default_factory=lambda: {
+            MCE_KEY: DEFAULT_MCE_KAFKA_TOPIC,
+            MCP_KEY: DEFAULT_MCP_KAFKA_TOPIC,
+        },
+        description="Logical event key → pgQueue logical topic name (often same as Kafka topic name).",
+    )
+
+    content_type: str = Field(
+        default="application/avro",
+        description=(
+            "Logical payload MIME after decompression; resolved to message.content_type_id (or omitted "
+            "when equal to the topic default)."
+        ),
+    )
+
+    payload_compression: Literal["NONE", "SNAPPY"] = Field(
+        default="SNAPPY",
+        description=(
+            "Application-layer codec for serialized Avro bytes; stored in message.payload_compression. "
+            "Align with postgres.pgQueue.payloadCompression / DATAHUB_PGQUEUE_PAYLOAD_COMPRESSION when "
+            "emitting to GMS."
+        ),
+    )
+
+    default_priority: int = Field(
+        default=5,
+        ge=0,
+        le=9,
+        description="Enqueue priority (0 = highest, 9 = lowest, 5 = default/normal).",
+    )
+
+    @field_validator("topic_routes", mode="after")
+    @classmethod
+    def validate_topic_routes(cls, v: Dict[str, str]) -> Dict[str, str]:
+        assert MCP_KEY in v, f"topic_routes must contain a route for {MCP_KEY}"
+        if MCE_KEY not in v:
+            logger.warning(
+                "%s not configured in topic_routes; MCE emissions will fail.", MCE_KEY
+            )
+        return v
+
+
+class PgQueueConsumerConfig(ConfigModel):
+    """Consume pgQueue messages and deserialize Avro like DataHubKafkaReader."""
+
+    queue: PgQueueConnectionConfig
+
+    schema_registry_url: str = Field(default_factory=_get_schema_registry_url)
+
+    schema_registry_config: Dict[str, object] = Field(default_factory=dict)
+
+    topic_routes: Dict[str, str] = Field(
+        default_factory=lambda: {
+            MCE_KEY: DEFAULT_MCE_KAFKA_TOPIC,
+            MCP_KEY: DEFAULT_MCP_KAFKA_TOPIC,
+        },
+        description="Logical event key → pgQueue logical topic name.",
+    )
+
+    consumer_group: str = Field(
+        default="datahub_ingestion_pgqueue",
+        description="Stored in consumer_offset and lock_owner prefix.",
+    )
+
+    visibility_timeout_seconds: Optional[int] = Field(
+        default=None,
+        description="Override queue.topic_defaults.visibility_timeout_seconds when set.",
+    )
+
+    payload_kind_by_route_key: Dict[str, PayloadRouteKind] = Field(
+        default_factory=_default_payload_kinds,
+        description="Controls Avro deserialization wrapper for each logical route key.",
+    )

--- a/metadata-ingestion/src/datahub/pgqueue/connection.py
+++ b/metadata-ingestion/src/datahub/pgqueue/connection.py
@@ -1,0 +1,135 @@
+"""psycopg2 connection factory with optional RDS IAM authentication.
+
+This module intentionally avoids importing ``datahub.ingestion.source.*`` at import time.
+RDS IAM support lazy-imports ``AwsConnectionConfig`` / ``RDSIAMTokenManager`` only when
+``auth_mode`` is :class:`~datahub.pgqueue.config.PgQueueAuthMode.AWS_IAM`, mirroring the
+Java-side isolation of pgQueue's DB access from general metadata ingestion.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Optional
+
+from datahub.pgqueue.config import PgQueueAuthMode, PgQueueConnectionConfig
+from datahub.pgqueue.host_port import parse_host_port
+
+if TYPE_CHECKING:
+    from psycopg2.extensions import connection as PGConnection
+
+logger = logging.getLogger(__name__)
+
+
+def create_pgqueue_connection(config: PgQueueConnectionConfig) -> "PGConnection":
+    """Open a new PostgreSQL connection suitable for pgQueue operations."""
+    import psycopg2
+
+    kwargs = build_psycopg2_connect_kwargs(config)
+    conn = psycopg2.connect(**kwargs)
+    return conn
+
+
+def flush_pg_connection(conn: "PGConnection") -> None:
+    """Align connection transaction state at flush boundaries (Kafka sink parity).
+
+    Repository helpers disable autocommit, commit, then restore the prior flag. If an
+    error leaves the session *idle in failed transaction*, toggling autocommit can
+    fail until rollback — callers should use :func:`restore_pg_connection_autocommit`
+    after each block; this function commits an open transaction or rolls back a
+    failed one at work-unit boundaries (see :meth:`DatahubPgQueueEmitter.flush`).
+    """
+    if getattr(conn, "closed", 0):
+        return
+    try:
+        from psycopg2 import extensions
+    except ImportError:
+        return
+    try:
+        status = conn.get_transaction_status()
+    except Exception:
+        return
+    if status == extensions.TRANSACTION_STATUS_INERROR:
+        try:
+            conn.rollback()
+        except Exception:
+            logger.debug("flush_pg_connection: rollback failed", exc_info=True)
+        return
+    if status == extensions.TRANSACTION_STATUS_INTRANS:
+        try:
+            conn.commit()
+        except Exception:
+            logger.warning("flush_pg_connection: commit failed", exc_info=True)
+            try:
+                conn.rollback()
+            except Exception:
+                logger.debug(
+                    "flush_pg_connection: rollback after failed commit", exc_info=True
+                )
+
+
+def restore_pg_connection_autocommit(
+    conn: "PGConnection", saved_autocommit: bool
+) -> None:
+    """Restore ``autocommit`` after a transactional block; rollback if the session aborted."""
+    try:
+        from psycopg2 import extensions
+
+        if conn.get_transaction_status() == extensions.TRANSACTION_STATUS_INERROR:
+            conn.rollback()
+    except Exception:
+        logger.debug(
+            "restore_pg_connection_autocommit: pre-restore check failed",
+            exc_info=True,
+        )
+    try:
+        conn.autocommit = saved_autocommit
+    except Exception:
+        logger.debug("restore_pg_connection_autocommit: failed", exc_info=True)
+
+
+def build_psycopg2_connect_kwargs(config: PgQueueConnectionConfig) -> dict:
+    host, port = parse_host_port(config.host_port, default_port=5432)
+    if port is None:
+        raise ValueError(f"Could not parse port from host_port={config.host_port!r}")
+
+    sslmode = config.sslmode
+    password: Optional[str] = None
+
+    if config.auth_mode == PgQueueAuthMode.PASSWORD:
+        assert config.password is not None
+        password = config.password.get_secret_value()
+    elif config.auth_mode == PgQueueAuthMode.AWS_IAM:
+        from datahub.ingestion.source.aws.aws_common import (
+            AwsConnectionConfig,
+            RDSIAMTokenManager,
+        )
+
+        aws_cfg = AwsConnectionConfig.model_validate(config.aws_config)
+        mgr = RDSIAMTokenManager(
+            endpoint=host,
+            username=config.username,
+            port=port,
+            aws_config=aws_cfg,
+        )
+        password = mgr.get_token()
+        if sslmode not in ("require", "verify-ca", "verify-full"):
+            sslmode = "require"
+
+    return {
+        "host": host,
+        "port": port,
+        "dbname": config.database,
+        "user": config.username,
+        "password": password,
+        "sslmode": sslmode,
+        "connect_timeout": config.connect_timeout_seconds,
+    }
+
+
+def consumer_lock_owner(consumer_group: str) -> str:
+    """Unique lock_owner string per consumer process.
+
+    Matches the Java format in PgQueuePollWorker: ``{consumerGroupId}:{UUID}``.
+    """
+    return f"{consumer_group}:{uuid.uuid4()}"

--- a/metadata-ingestion/src/datahub/pgqueue/consumer.py
+++ b/metadata-ingestion/src/datahub/pgqueue/consumer.py
@@ -1,0 +1,237 @@
+"""Poll pgQueue tables and deserialize Confluent Avro payloads like Kafka consumers."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, Dict, List, Optional, Sequence, Union, cast
+
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.avro import AvroDeserializer
+from confluent_kafka.serialization import MessageField, SerializationContext
+
+from datahub.emitter.kafka_emitter import MCE_KEY, MCP_KEY
+from datahub.ingestion.api.closeable import Closeable
+from datahub.metadata.schema_classes import (
+    MetadataChangeEventClass as MetadataChangeEvent,
+    MetadataChangeLogClass,
+    MetadataChangeProposalClass as MetadataChangeProposal,
+)
+from datahub.pgqueue.compression import decode_stored, from_wire
+from datahub.pgqueue.config import PgQueueConsumerConfig
+from datahub.pgqueue.connection import consumer_lock_owner, create_pgqueue_connection
+from datahub.pgqueue.priority_bands import resolve_priority_bands_json
+from datahub.pgqueue.repository import (
+    PgQueueMessageHandle,
+    PgQueueReceivedMessage,
+    PgQueueRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PgQueueConsumedRecord:
+    """One leased message plus a deserialized Avro payload (MCP/MCE/MCL or PE dict)."""
+
+    route_key: str
+    topic_name: str
+    raw: PgQueueReceivedMessage
+    record: Union[
+        MetadataChangeEvent,
+        MetadataChangeProposal,
+        MetadataChangeLogClass,
+        Dict[str, Any],
+    ]
+
+
+def build_pg_queue_event_meta(rec: PgQueueConsumedRecord) -> Dict[str, Any]:
+    """Build ``EventEnvelope.meta`` so consumers can ack via :class:`PgQueueMessageHandle`."""
+    h = rec.raw.handle
+    return {
+        "pg_queue": {
+            "topic": rec.topic_name,
+            "partition": h.partition_id,
+            "enqueue_seq": h.enqueue_seq,
+            "routing_key": rec.raw.routing_key,
+            "handle": h.to_meta_dict(),
+        }
+    }
+
+
+class DatahubPgQueueConsumer(Closeable):
+    """Poll partitions under a logical Kafka-style topic name stored in pgQueue."""
+
+    def __init__(
+        self,
+        config: PgQueueConsumerConfig,
+        server_config: Optional[Dict[str, Any]] = None,
+    ):
+        self.config = config
+        qconf = config.queue
+        self._repo = PgQueueRepository(qconf.queue_schema, qconf.table_prefix)
+        self._conn = create_pgqueue_connection(qconf)
+        self._lock_owner = consumer_lock_owner(config.consumer_group)
+        self._priority_bands_json = resolve_priority_bands_json(
+            server_config=server_config,
+            env_override=None,
+        )
+
+        sr_conf = {"url": config.schema_registry_url, **config.schema_registry_config}
+        registry = SchemaRegistryClient(sr_conf)
+        self._avro_deserializer = AvroDeserializer(
+            schema_registry_client=registry,
+            return_record_name=True,
+        )
+
+    def visibility_timedelta(self) -> timedelta:
+        secs = self.config.visibility_timeout_seconds
+        if secs is None:
+            secs = self.config.queue.topic_defaults.visibility_timeout_seconds
+        return timedelta(seconds=float(secs))
+
+    def poll_route_key(
+        self,
+        route_key: str,
+        *,
+        max_messages: int = 100,
+        partition_ids: Optional[Sequence[int]] = None,
+    ) -> List[PgQueueConsumedRecord]:
+        """Drain up to ``max_messages`` messages with acquired per-group leases."""
+        if route_key not in self.config.topic_routes:
+            raise ValueError(f"route_key {route_key!r} missing from topic_routes")
+
+        topic_name = self.config.topic_routes[route_key]
+        meta = self._repo.fetch_topic_row(self._conn, topic_name)
+        if meta is None:
+            logger.debug("pgQueue topic %s does not exist yet", topic_name)
+            return []
+
+        topic_id, partition_count, _default_content_type_id = meta
+        self._repo.register_consumer(self._conn, self.config.consumer_group, topic_id)
+        parts_tuple = tuple(
+            int(pid)
+            for pid in (
+                partition_ids if partition_ids is not None else range(partition_count)
+            )
+        )
+
+        vis = self.visibility_timedelta()
+        locked = self._repo.receive_batch_for_group(
+            self._conn,
+            consumer_group=self.config.consumer_group,
+            topic_id=topic_id,
+            partition_ids=parts_tuple,
+            lock_owner=self._lock_owner,
+            visibility_timeout=vis,
+            max_messages=max_messages,
+            priority_bands_json=self._priority_bands_json,
+        )
+
+        out: List[PgQueueConsumedRecord] = []
+        for raw in locked:
+            inner = decode_stored(raw.payload, from_wire(raw.payload_compression))
+            record = self._deserialize(route_key, topic_name, inner)
+            out.append(
+                PgQueueConsumedRecord(
+                    route_key=route_key,
+                    topic_name=topic_name,
+                    raw=raw,
+                    record=record,
+                )
+            )
+
+        return out
+
+    def poll_route_keys(
+        self,
+        route_keys: Sequence[str],
+        *,
+        max_messages: int = 100,
+        partition_ids: Optional[Sequence[int]] = None,
+    ) -> List[PgQueueConsumedRecord]:
+        """Drain each route key in order, up to ``max_messages`` per key."""
+        out: List[PgQueueConsumedRecord] = []
+        for rk in route_keys:
+            out.extend(
+                self.poll_route_key(
+                    rk, max_messages=max_messages, partition_ids=partition_ids
+                )
+            )
+        return out
+
+    def ack(self, handles: Sequence[PgQueueMessageHandle]) -> int:
+        """Advance consumer group offsets for the given handles."""
+        return self._repo.commit_for_group(
+            self._conn,
+            self.config.consumer_group,
+            handles,
+        )
+
+    def ack_records(self, records: Sequence[PgQueueConsumedRecord]) -> int:
+        return self.ack([r.raw.handle for r in records])
+
+    def extend_visibility(
+        self,
+        handles: Sequence[PgQueueMessageHandle],
+        *,
+        extend_by: timedelta,
+    ) -> int:
+        return self._repo.extend_visibility_for_group(
+            self._conn,
+            self.config.consumer_group,
+            handles,
+            lock_owner=self._lock_owner,
+            extend_by=extend_by,
+        )
+
+    def _deserialize(
+        self, route_key: str, topic_name: str, payload: bytes
+    ) -> Union[
+        MetadataChangeEvent,
+        MetadataChangeProposal,
+        MetadataChangeLogClass,
+        Dict[str, Any],
+    ]:
+        kind = self.config.payload_kind_by_route_key.get(route_key, "mcp")
+        ctx = SerializationContext(topic_name, MessageField.VALUE)
+        deserialized = self._avro_deserializer(payload, ctx)
+        if kind == "mcp":
+            return MetadataChangeProposal.from_obj(deserialized, tuples=True)
+        if kind == "mce":
+            return MetadataChangeEvent.from_obj(deserialized, tuples=True)
+        if kind == "mcl":
+            return MetadataChangeLogClass.from_obj(deserialized, tuples=True)
+        if kind == "pe":
+            return cast(Dict[str, Any], deserialized)
+        raise ValueError(f"Unsupported payload kind {kind!r} for route {route_key}")
+
+    def lock_owner(self) -> str:
+        return self._lock_owner
+
+    def close(self) -> None:
+        self._conn.close()
+
+
+def poll_mcp_messages(
+    consumer: DatahubPgQueueConsumer,
+    *,
+    max_messages: int = 100,
+    partition_ids: Optional[Sequence[int]] = None,
+) -> List[PgQueueConsumedRecord]:
+    """Convenience wrapper matching default MCP-focused ingestion."""
+    return consumer.poll_route_key(
+        MCP_KEY, max_messages=max_messages, partition_ids=partition_ids
+    )
+
+
+def poll_mce_messages(
+    consumer: DatahubPgQueueConsumer,
+    *,
+    max_messages: int = 100,
+    partition_ids: Optional[Sequence[int]] = None,
+) -> List[PgQueueConsumedRecord]:
+    return consumer.poll_route_key(
+        MCE_KEY, max_messages=max_messages, partition_ids=partition_ids
+    )

--- a/metadata-ingestion/src/datahub/pgqueue/emitter.py
+++ b/metadata-ingestion/src/datahub/pgqueue/emitter.py
@@ -1,0 +1,234 @@
+"""Kafka-compatible Avro producer backed by pgQueue tables."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.avro import AvroSerializer
+from confluent_kafka.serialization import MessageField, SerializationContext
+
+from datahub.emitter.generic_emitter import Emitter
+from datahub.emitter.kafka_emitter import (
+    MCE_KEY,
+    MCP_KEY,
+    KafkaEmitterConfig,
+)
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.closeable import Closeable
+from datahub.metadata.schema_classes import (
+    MetadataChangeEventClass as MetadataChangeEvent,
+    MetadataChangeProposalClass as MetadataChangeProposal,
+)
+from datahub.metadata.schemas import (
+    getMetadataChangeEventSchema,
+    getMetadataChangeProposalSchema,
+)
+from datahub.pgqueue.compression import (
+    PgQueuePayloadCompression,
+    encode_inner,
+)
+from datahub.pgqueue.config import PgQueueEmitterConfig
+from datahub.pgqueue.connection import create_pgqueue_connection, flush_pg_connection
+from datahub.pgqueue.repository import EnqueueBatchItem, PgQueueRepository
+
+logger = logging.getLogger(__name__)
+
+
+class DatahubPgQueueEmitter(Closeable, Emitter):
+    """Serialize MCP/MCE like ``DatahubKafkaEmitter`` but persist bytes to PostgreSQL."""
+
+    def __init__(self, config: PgQueueEmitterConfig):
+        self.config = config
+        qconf = config.queue
+        self._repo = PgQueueRepository(qconf.queue_schema, qconf.table_prefix)
+
+        schema_registry_conf = {
+            "url": config.schema_registry_url,
+            **config.schema_registry_config,
+        }
+        registry = SchemaRegistryClient(schema_registry_conf)
+
+        def mce_dict(mce: MetadataChangeEvent, ctx: SerializationContext) -> dict:
+            return mce.to_obj(tuples=True)
+
+        def mcp_dict(
+            mcp: Union[MetadataChangeProposal, MetadataChangeProposalWrapper],
+            ctx: SerializationContext,
+        ) -> dict:
+            return mcp.to_obj(tuples=True)
+
+        self._mce_serializer = AvroSerializer(
+            schema_str=getMetadataChangeEventSchema(),
+            schema_registry_client=registry,
+            to_dict=mce_dict,
+        )
+        self._mcp_serializer = AvroSerializer(
+            schema_str=getMetadataChangeProposalSchema(),
+            schema_registry_client=registry,
+            to_dict=mcp_dict,
+        )
+
+        self._conn = create_pgqueue_connection(qconf)
+
+    def _serialize_for_enqueue(
+        self,
+        item: Union[
+            MetadataChangeEvent,
+            MetadataChangeProposal,
+            MetadataChangeProposalWrapper,
+        ],
+    ) -> Tuple[str, str, bytes]:
+        """Return logical queue topic name, routing key, Avro payload bytes."""
+        payload_obj: Union[
+            MetadataChangeEvent,
+            MetadataChangeProposal,
+            MetadataChangeProposalWrapper,
+        ]
+        if isinstance(item, (MetadataChangeProposal, MetadataChangeProposalWrapper)):
+            topic_name = self.config.topic_routes[MCP_KEY]
+            kafka_topic_for_sr = topic_name
+            urn = item.entityUrn
+            if urn is None:
+                raise ValueError(
+                    "MetadataChangeProposal requires entityUrn for pgQueue routing key"
+                )
+            key = urn
+            serializer = self._mcp_serializer
+            payload_obj = item
+        else:
+            if MCE_KEY not in self.config.topic_routes:
+                raise ValueError(
+                    f"Cannot emit MetadataChangeEvent: {MCE_KEY} missing from topic_routes"
+                )
+            topic_name = self.config.topic_routes[MCE_KEY]
+            kafka_topic_for_sr = topic_name
+            key = item.proposedSnapshot.urn
+            serializer = self._mce_serializer
+            payload_obj = item
+
+        ctx = SerializationContext(kafka_topic_for_sr, MessageField.VALUE)
+        serialized = serializer(payload_obj, ctx)
+        if serialized is None:
+            raise RuntimeError("Avro serialization returned None")
+        return topic_name, key, serialized
+
+    def emit(
+        self,
+        item: Union[
+            MetadataChangeEvent,
+            MetadataChangeProposal,
+            MetadataChangeProposalWrapper,
+        ],
+        callback: Optional[Callable[[Exception, str], None]] = None,
+    ) -> None:
+        cb = callback or _error_reporting_callback
+        try:
+            topic_name, key, serialized = self._serialize_for_enqueue(item)
+            td = self.config.queue.merged_topic_defaults_for(topic_name)
+            mode = PgQueuePayloadCompression[self.config.payload_compression]
+            stored = encode_inner(serialized, mode)
+            self._repo.enqueue(
+                self._conn,
+                topic_name=topic_name,
+                routing_key=key,
+                partition_count=td.partition_count,
+                retention_max_age_seconds=td.retention_max_age_seconds,
+                max_rows_per_topic=td.max_rows_per_topic,
+                max_total_payload_bytes=td.max_total_payload_bytes_per_topic,
+                default_content_type_mime=td.default_content_type_mime,
+                priority=self.config.default_priority,
+                payload=stored,
+                content_type=self.config.content_type,
+                headers=(),
+                payload_compression=int(mode),
+            )
+            cb(None, "pgQueue enqueue succeeded")  # type: ignore[arg-type]
+        except Exception as e:
+            cb(e, "pgQueue enqueue failed")
+
+    def emit_batch(
+        self,
+        items: Sequence[
+            Union[
+                MetadataChangeEvent,
+                MetadataChangeProposal,
+                MetadataChangeProposalWrapper,
+            ]
+        ],
+        callback: Optional[Callable[[Exception, str], None]] = None,
+    ) -> None:
+        """Serialize many records and enqueue them in a single PostgreSQL transaction."""
+        cb = callback or _error_reporting_callback
+        if not items:
+            return
+        try:
+            batch_items: List[EnqueueBatchItem] = []
+            topic_names: List[str] = []
+            mode = PgQueuePayloadCompression[self.config.payload_compression]
+            for item in items:
+                topic_name, key, serialized = self._serialize_for_enqueue(item)
+                topic_names.append(topic_name)
+                stored = encode_inner(serialized, mode)
+                batch_items.append(
+                    EnqueueBatchItem(
+                        topic_name=topic_name,
+                        routing_key=key,
+                        priority=self.config.default_priority,
+                        payload=stored,
+                        content_type=self.config.content_type,
+                        headers=(),
+                        payload_compression=int(mode),
+                    )
+                )
+            if len(set(topic_names)) != 1:
+                raise ValueError(
+                    "emit_batch requires a single topic per batch for pgQueue defaults resolution; "
+                    f"got topics={sorted(set(topic_names))}"
+                )
+            td = self.config.queue.merged_topic_defaults_for(topic_names[0])
+            self._repo.enqueue_batch(
+                self._conn,
+                batch_items,
+                partition_count=td.partition_count,
+                retention_max_age_seconds=td.retention_max_age_seconds,
+                max_rows_per_topic=td.max_rows_per_topic,
+                max_total_payload_bytes=td.max_total_payload_bytes_per_topic,
+                default_content_type_mime=td.default_content_type_mime,
+            )
+            for _ in items:
+                cb(None, "pgQueue enqueue succeeded")  # type: ignore[arg-type]
+        except Exception as e:
+            cb(e, "pgQueue enqueue failed")
+
+    def flush(self) -> None:
+        """Ensure the session matches Kafka sink semantics at work-unit boundaries.
+
+        Each ``enqueue`` / ``enqueue_batch`` commits independently; this commits any
+        still-open transaction (e.g. stray ``idle in transaction``) and rolls back
+        ``idle in failed transaction`` before autocommit restore in the repository.
+        """
+        flush_pg_connection(self._conn)
+
+    def close(self) -> None:
+        try:
+            self.flush()
+        finally:
+            self._conn.close()
+
+
+def kafka_emitter_config_from_pg_queue(
+    kafka_subset: KafkaEmitterConfig,
+) -> Dict[str, object]:
+    """Helper for configs that mirror Kafka emitter Schema Registry settings."""
+    return {
+        "schema_registry_url": kafka_subset.connection.schema_registry_url,
+        "schema_registry_config": kafka_subset.connection.schema_registry_config,
+        "topic_routes": kafka_subset.topic_routes,
+    }
+
+
+def _error_reporting_callback(err: Optional[Exception], msg: str) -> None:
+    if err:
+        logger.error("Failed to emit to pgQueue: %s %s", err, msg)

--- a/metadata-ingestion/src/datahub/pgqueue/headers.py
+++ b/metadata-ingestion/src/datahub/pgqueue/headers.py
@@ -1,0 +1,54 @@
+"""Kafka-compatible pgQueue message headers (JSONB in PostgreSQL)."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, List, Sequence, Tuple
+
+HeaderList = List[Tuple[str, bytes]]
+
+KEY_FIELD = "key"
+VALUE_B64_FIELD = "v"
+
+
+def headers_to_json(headers: Sequence[Tuple[str, bytes]]) -> str | None:
+    """Serialize headers for JSONB column; empty sequence stores SQL NULL."""
+    if len(headers) == 0:
+        return None
+    arr = []
+    for k, v in headers:
+        arr.append(
+            {
+                KEY_FIELD: k,
+                VALUE_B64_FIELD: base64.standard_b64encode(v).decode("ascii"),
+            }
+        )
+    return json.dumps(arr, separators=(",", ":"))
+
+
+def headers_from_db(raw: Any) -> HeaderList:
+    """Deserialize JSONB (string, dict/list, or bytes) to ordered ``(key, value)`` tuples."""
+    if raw is None:
+        return []
+    if isinstance(raw, memoryview):
+        raw = raw.tobytes()
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8")
+    if isinstance(raw, str):
+        if not raw.strip():
+            return []
+        parsed = json.loads(raw)
+    elif isinstance(raw, list):
+        parsed = raw
+    else:
+        return []
+
+    out: HeaderList = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get(KEY_FIELD, ""))
+        vb64 = str(item.get(VALUE_B64_FIELD, ""))
+        out.append((key, base64.standard_b64decode(vb64.encode("ascii"))))
+    return out

--- a/metadata-ingestion/src/datahub/pgqueue/host_port.py
+++ b/metadata-ingestion/src/datahub/pgqueue/host_port.py
@@ -1,0 +1,26 @@
+"""Host/port parsing for PostgreSQL connectivity (stdlib-only; avoids ingestion SQL helpers)."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+
+def parse_host_port(
+    host_port: str, default_port: Optional[int] = None
+) -> Tuple[str, Optional[int]]:
+    """
+    Parse a host:port string into separate host and port components.
+
+    Same behavior as ``datahub.ingestion.source.sql.sqlalchemy_uri.parse_host_port``,
+    kept local so pgQueue's psycopg2 stack does not depend on ingestion sources.
+    """
+    try:
+        host, port_str = host_port.rsplit(":", 1)
+        port: Optional[int]
+        try:
+            port = int(port_str)
+        except ValueError:
+            port = default_port
+        return host, port
+    except ValueError:
+        return host_port, default_port

--- a/metadata-ingestion/src/datahub/pgqueue/offset_skew.py
+++ b/metadata-ingestion/src/datahub/pgqueue/offset_skew.py
@@ -1,0 +1,51 @@
+"""STUCK_AHEAD detection and rate-limited warnings for pgQueue consumer offsets."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_WARN_INTERVAL_SEC = 60.0
+_last_warn_at: Dict[str, float] = {}
+
+
+@dataclass(frozen=True)
+class PartitionOffsetSkew:
+    consumer_group: str
+    topic_id: int
+    partition_id: int
+    committed_offset: int
+    max_seq: int
+    ahead_by: int
+    topic_name: Optional[str] = None
+
+
+def warn_if_ahead(skew: PartitionOffsetSkew) -> None:
+    key = f"{skew.consumer_group}:{skew.topic_id}:{skew.partition_id}"
+    now = time.monotonic()
+    last = _last_warn_at.get(key)
+    if last is not None and now - last < _WARN_INTERVAL_SEC:
+        return
+    _last_warn_at[key] = now
+    logger.warning(
+        "pgQueue consumer offset ahead of message log (STUCK_AHEAD); consumer will not receive "
+        "messages until an operator resets the offset (see docs/pgqueue-design.md). "
+        "consumerGroup=%s topicId=%s topicName=%s partitionId=%s committedOffset=%s "
+        "maxSeq=%s aheadBy=%s",
+        skew.consumer_group,
+        skew.topic_id,
+        skew.topic_name,
+        skew.partition_id,
+        skew.committed_offset,
+        skew.max_seq,
+        skew.ahead_by,
+    )
+
+
+def warn_all(skews: List[PartitionOffsetSkew]) -> None:
+    for skew in skews:
+        warn_if_ahead(skew)

--- a/metadata-ingestion/src/datahub/pgqueue/priority_bands.py
+++ b/metadata-ingestion/src/datahub/pgqueue/priority_bands.py
@@ -1,0 +1,153 @@
+"""Priority band configuration and weighted fair queuing for pgQueue dequeue."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, TypeVar
+
+MIN_PRIORITY = 0
+MAX_PRIORITY = 9
+DEFAULT_PRIORITY = 5
+
+DEFAULT_BANDS_JSON = '[{"range":[0,3],"weight":70},{"range":[4,6],"weight":20},{"range":[7,9],"weight":10}]'
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class PriorityBand:
+    min_priority: int
+    max_priority: int
+    weight: int
+
+    def __post_init__(self) -> None:
+        if self.min_priority < MIN_PRIORITY or self.min_priority > MAX_PRIORITY:
+            raise ValueError(f"min_priority {self.min_priority} out of range [0, 9]")
+        if self.max_priority < MIN_PRIORITY or self.max_priority > MAX_PRIORITY:
+            raise ValueError(f"max_priority {self.max_priority} out of range [0, 9]")
+        if self.min_priority > self.max_priority:
+            raise ValueError(
+                f"min_priority {self.min_priority} > max_priority {self.max_priority}"
+            )
+        if self.weight <= 0:
+            raise ValueError(f"weight must be positive, got {self.weight}")
+
+
+@dataclass(frozen=True)
+class PriorityBandConfig:
+    bands: List[PriorityBand]
+
+    def __post_init__(self) -> None:
+        if not self.bands:
+            raise ValueError("At least one priority band is required")
+        covered = [False] * (MAX_PRIORITY + 1)
+        for band in self.bands:
+            for p in range(band.min_priority, band.max_priority + 1):
+                if covered[p]:
+                    raise ValueError(
+                        f"Priority {p} is covered by multiple bands (overlap)"
+                    )
+                covered[p] = True
+        for p in range(MIN_PRIORITY, MAX_PRIORITY + 1):
+            if not covered[p]:
+                raise ValueError(
+                    f"Priority {p} is not covered by any band (gap in [0, 9])"
+                )
+
+    @staticmethod
+    def parse(json_str: str) -> PriorityBandConfig:
+        raw = json.loads(json_str)
+        bands = []
+        for entry in raw:
+            rng = entry.get("range")
+            if not rng or len(rng) != 2:
+                raise ValueError(
+                    "Each band must have a 'range' array of exactly 2 integers"
+                )
+            weight = entry.get("weight")
+            if weight is None:
+                raise ValueError("Each band must have a 'weight' field")
+            bands.append(PriorityBand(rng[0], rng[1], int(weight)))
+        return PriorityBandConfig(bands=bands)
+
+    def batch_limits(self, total: int) -> List[int]:
+        """Proportional per-band limits. Remainders go round-robin from first band."""
+        n = len(self.bands)
+        if total <= 0:
+            return [0] * n
+        total_weight = sum(b.weight for b in self.bands)
+        limits = [total * b.weight // total_weight for b in self.bands]
+        allocated = sum(limits)
+        remainder = total - allocated
+        for i in range(remainder):
+            limits[i % n] += 1
+        return limits
+
+
+def weighted_fair_fetch(
+    config: PriorityBandConfig,
+    total_limit: int,
+    fetch_fn: Callable[[int, int, int], List[T]],
+) -> List[T]:
+    """Fetch across bands with weighted fair queuing and greedy redistribution.
+
+    Args:
+        config: Priority band configuration.
+        total_limit: Total rows to fetch across all bands.
+        fetch_fn: ``(min_priority, max_priority, limit) -> rows`` callable.
+    """
+    if total_limit <= 0:
+        return []
+    limits = config.batch_limits(total_limit)
+    results: List[T] = []
+    remaining = total_limit
+    for i, band in enumerate(config.bands):
+        if remaining <= 0:
+            break
+        band_limit = min(limits[i], remaining)
+        if band_limit <= 0:
+            continue
+        fetched = fetch_fn(band.min_priority, band.max_priority, band_limit)
+        results.extend(fetched)
+        remaining -= len(fetched)
+        unused = band_limit - len(fetched)
+        if unused > 0 and i + 1 < len(config.bands):
+            limits[i + 1] += unused
+    return results
+
+
+PRIORITY_BANDS_ENV_VAR = "DATAHUB_PGQUEUE_PRIORITY_BANDS"
+
+
+def resolve_priority_bands_json(
+    server_config: Optional[Dict[str, Any]] = None,
+    env_override: Optional[str] = None,
+) -> str:
+    """Resolve priority bands JSON using the precedence hierarchy:
+
+    1. GMS server config (``/config`` endpoint → ``pgQueue.priorityBands``)
+    2. Environment variable (``DATAHUB_PGQUEUE_PRIORITY_BANDS``)
+    3. Hardcoded default (``DEFAULT_BANDS_JSON``)
+
+    Args:
+        server_config: Raw dict from GMS ``/config`` response (may be None if unavailable).
+        env_override: Explicit env value; if None, reads from os.environ.
+    """
+    if server_config:
+        pgqueue_cfg = server_config.get("pgQueue")
+        if isinstance(pgqueue_cfg, dict):
+            bands = pgqueue_cfg.get("priorityBands")
+            if bands and isinstance(bands, str):
+                return bands
+
+    env_val = (
+        env_override
+        if env_override is not None
+        else os.environ.get(PRIORITY_BANDS_ENV_VAR)
+    )
+    if env_val:
+        return env_val
+
+    return DEFAULT_BANDS_JSON

--- a/metadata-ingestion/src/datahub/pgqueue/repository.py
+++ b/metadata-ingestion/src/datahub/pgqueue/repository.py
@@ -1,0 +1,890 @@
+"""
+PostgreSQL queue persistence matching SqlSetup DDL under ``postgres.pgQueue``.
+
+This module only depends on other ``datahub.pgqueue.*`` helpers and standard/third-party
+libraries used for SQL (psycopg2); it does not import ``datahub.ingestion.source.*``, keeping
+the pgQueue DB client usable alongside catalog ingestion without coupling to source connectors.
+
+**Java alignment:** Java ``EbeanPostgresMetadataQueueStore`` and this Python repository match
+payload and Kafka-style headers (JSONB ``headers``). Keep JSON aligned with
+``com.linkedin.metadata.queue.QueueHeadersJson``.
+
+1. ``enqueue_seq`` allocation (per ``topic_id`` + ``partition_id``) — Python uses a
+   transaction-scoped advisory lock + ``MAX(enqueue_seq)+1``.
+2. Consumer progress is tracked via ``consumer_offset`` (``epoch`` /
+   ``offset_value`` semantics) plus per-group rows in ``message_group_lease``.
+   Dequeue acquires work only through leases (not row locks on ``message``).
+   ``consumer_offset.offset_value`` records the highest ``enqueue_seq`` committed
+   per group/partition using ``GREATEST`` so it never regresses.
+3. Visibility / ``lock_owner`` string format expected by peer clients (lease rows).
+4. Persisted ``routing_key`` on each message row (Kafka-style enqueue key; aligns with Java).
+5. Topic upsert: ``partition_count`` is set with ``GREATEST`` so it never drops below the prior
+   catalog value or below ``MAX(partition_id)+1`` over existing message rows (matches Java
+   ``EbeanPostgresMetadataQueueStore`` / SqlSetup).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from datahub.pgqueue.connection import (
+    flush_pg_connection,
+    restore_pg_connection_autocommit,
+)
+from datahub.pgqueue.headers import headers_from_db, headers_to_json
+from datahub.pgqueue.offset_skew import PartitionOffsetSkew, warn_if_ahead
+from datahub.pgqueue.priority_bands import DEFAULT_BANDS_JSON, PriorityBandConfig
+from datahub.pgqueue.sql import qualified_table
+
+if TYPE_CHECKING:
+    from psycopg2.extensions import connection as PGConnection
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PgQueueMessageHandle:
+    """Primary key plus routing fields required for acks and visibility heartbeats."""
+
+    id: int
+    enqueued_at: datetime
+    topic_id: int
+    partition_id: int
+    enqueue_seq: int
+
+    def to_meta_dict(self) -> Dict[str, Any]:
+        """Plain dict for embedding in pipeline/event metadata (e.g. actions ack correlation)."""
+        return {
+            "id": self.id,
+            "enqueued_at": self.enqueued_at.isoformat(),
+            "topic_id": self.topic_id,
+            "partition_id": self.partition_id,
+            "enqueue_seq": self.enqueue_seq,
+        }
+
+    @classmethod
+    def from_meta_dict(cls, data: Dict[str, Any]) -> PgQueueMessageHandle:
+        raw_enq = data["enqueued_at"]
+        enqueued_at = (
+            datetime.fromisoformat(raw_enq) if isinstance(raw_enq, str) else raw_enq
+        )
+        return cls(
+            id=int(data["id"]),
+            enqueued_at=enqueued_at,
+            topic_id=int(data["topic_id"]),
+            partition_id=int(data["partition_id"]),
+            enqueue_seq=int(data["enqueue_seq"]),
+        )
+
+
+@dataclass(frozen=True)
+class PgQueueReceivedMessage:
+    """A queue message with an acquired per-consumer-group lease."""
+
+    handle: PgQueueMessageHandle
+    priority: int
+    payload: bytes
+    content_type: Optional[str]
+    payload_compression: int
+    headers: Tuple[Tuple[str, bytes], ...]
+    routing_key: str
+    lock_owner: str
+
+
+@dataclass(frozen=True)
+class EnqueueBatchItem:
+    """One logical message in a bulk enqueue call (see :meth:`PgQueueRepository.enqueue_batch`)."""
+
+    topic_name: str
+    routing_key: str
+    priority: int
+    payload: bytes
+    content_type: Optional[str]
+    headers: Sequence[Tuple[str, bytes]]
+    payload_compression: int = 0
+
+
+def advisory_lock_key(topic_id: int, partition_id: int) -> int:
+    """Deterministic positive bigint for ``pg_advisory_xact_lock``."""
+    digest = hashlib.sha256(f"{topic_id}:{partition_id}".encode("utf-8")).digest()
+    n = int.from_bytes(digest[:8], byteorder="big", signed=False)
+    # Keep in signed 63-bit positive range for broad server compatibility.
+    return n % (2**62)
+
+
+def stable_partition_id(routing_key: str, partition_count: int) -> int:
+    """CRC32 partition assignment (stable across Python runs)."""
+    if partition_count <= 0:
+        raise ValueError("partition_count must be positive")
+    import zlib
+
+    crc = zlib.crc32(routing_key.encode("utf-8")) & 0xFFFFFFFF
+    return crc % partition_count
+
+
+class PgQueueRepository:
+    def __init__(self, schema: str, table_prefix: str) -> None:
+        self._topic = qualified_table(schema, table_prefix, "topic")
+        self._message = qualified_table(schema, table_prefix, "message")
+        self._consumer_offset = qualified_table(schema, table_prefix, "consumer_offset")
+        self._content_type = qualified_table(schema, table_prefix, "content_type")
+        self._consumer_registration = qualified_table(
+            schema, table_prefix, "consumer_registration"
+        )
+        self._lease = qualified_table(schema, table_prefix, "message_group_lease")
+
+    def fetch_topic_row(
+        self, conn: PGConnection, topic_name: str
+    ) -> Optional[Tuple[int, int, Optional[int]]]:
+        """Return ``(topic_id, partition_count, default_content_type_id)`` or None."""
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT id, partition_count, default_content_type_id FROM {self._topic} WHERE topic_name = %s",
+                (topic_name,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            dct = int(row[2]) if row[2] is not None else None
+            return int(row[0]), int(row[1]), dct
+
+    def _ensure_mime_registered(self, conn: PGConnection, mime: str) -> int:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"INSERT INTO {self._content_type} (mime) VALUES (%s) ON CONFLICT (mime) DO NOTHING",
+                (mime,),
+            )
+            cur.execute(
+                f"SELECT id FROM {self._content_type} WHERE mime = %s",
+                (mime,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            return int(row[0])
+
+    def ensure_topic(
+        self,
+        conn: PGConnection,
+        topic_name: str,
+        partition_count: int,
+        retention_max_age_seconds: int,
+        max_rows_per_topic: int,
+        max_total_payload_bytes: int,
+        default_content_type_mime: Optional[str] = None,
+    ) -> int:
+        """Upsert topic catalog row and return ``topic_id``."""
+        mime = default_content_type_mime or "application/avro"
+        default_ct_id = self._ensure_mime_registered(conn, mime)
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._topic} AS ptopic
+                  (topic_name, partition_count,
+                   retention_max_age_seconds, max_rows_per_topic, max_total_payload_bytes,
+                   default_content_type_id)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (topic_name) DO UPDATE SET
+                  partition_count = GREATEST(
+                    1,
+                    EXCLUDED.partition_count,
+                    ptopic.partition_count,
+                    COALESCE(
+                      (
+                        SELECT MAX(m.partition_id)
+                        FROM {self._message} m
+                        WHERE m.topic_id = ptopic.id
+                      ),
+                      -1
+                    ) + 1
+                  ),
+                  retention_max_age_seconds = EXCLUDED.retention_max_age_seconds,
+                  max_rows_per_topic = EXCLUDED.max_rows_per_topic,
+                  max_total_payload_bytes = EXCLUDED.max_total_payload_bytes,
+                  default_content_type_id = EXCLUDED.default_content_type_id
+                """,
+                (
+                    topic_name,
+                    partition_count,
+                    retention_max_age_seconds,
+                    max_rows_per_topic,
+                    max_total_payload_bytes,
+                    default_ct_id,
+                ),
+            )
+            cur.execute(
+                f"SELECT id FROM {self._topic} WHERE topic_name = %s",
+                (topic_name,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            return int(row[0])
+
+    def _compute_stored_content_type_id(
+        self,
+        conn: PGConnection,
+        topic_default_id: Optional[int],
+        content_type: Optional[str],
+    ) -> Optional[int]:
+        if not content_type:
+            return None
+        cid = self._ensure_mime_registered(conn, content_type)
+        if topic_default_id is not None and topic_default_id == cid:
+            return None
+        return cid
+
+    def _enqueue_message_in_transaction(
+        self,
+        conn: PGConnection,
+        *,
+        topic_name: str,
+        routing_key: str,
+        partition_count: int,
+        retention_max_age_seconds: int,
+        max_rows_per_topic: int,
+        max_total_payload_bytes: int,
+        default_content_type_mime: Optional[str],
+        priority: int,
+        payload: bytes,
+        content_type: Optional[str],
+        headers: Sequence[Tuple[str, bytes]],
+        payload_compression: int = 0,
+    ) -> PgQueueMessageHandle:
+        """Insert one row inside the caller's open transaction (no commit)."""
+        self.ensure_topic(
+            conn,
+            topic_name,
+            partition_count,
+            retention_max_age_seconds,
+            max_rows_per_topic,
+            max_total_payload_bytes,
+            default_content_type_mime=default_content_type_mime,
+        )
+        row_meta = self.fetch_topic_row(conn, topic_name)
+        assert row_meta is not None
+        topic_id, pc, topic_default_ct_id = row_meta
+        if priority < 0 or priority > 9:
+            raise ValueError(f"priority {priority} out of range [0, 9]")
+        partition_id = stable_partition_id(routing_key, pc)
+        stored_ct_id = self._compute_stored_content_type_id(
+            conn, topic_default_ct_id, content_type
+        )
+
+        lock_k = advisory_lock_key(topic_id, partition_id)
+        hdr_json = headers_to_json(headers)
+        with conn.cursor() as cur:
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", (lock_k,))
+            cur.execute(
+                f"""
+                WITH mx AS (
+                  SELECT COALESCE(MAX(enqueue_seq), 0) AS max_seq
+                  FROM {self._message}
+                  WHERE topic_id = %s AND partition_id = %s
+                )
+                INSERT INTO {self._message}
+                  (topic_id, partition_id, routing_key, enqueue_seq, priority, payload, content_type_id, payload_compression, headers)
+                SELECT %s, %s, %s, mx.max_seq + 1, %s, %s, %s, %s, CAST(%s AS jsonb)
+                FROM mx
+                RETURNING id, enqueued_at, enqueue_seq
+                """,
+                (
+                    topic_id,
+                    partition_id,
+                    topic_id,
+                    partition_id,
+                    routing_key,
+                    priority,
+                    payload,
+                    stored_ct_id,
+                    payload_compression,
+                    hdr_json,
+                ),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            mid = int(row[0])
+            enq_at = row[1]
+            enq_seq = int(row[2])
+
+        return PgQueueMessageHandle(
+            id=mid,
+            enqueued_at=enq_at,
+            topic_id=topic_id,
+            partition_id=partition_id,
+            enqueue_seq=enq_seq,
+        )
+
+    def enqueue(
+        self,
+        conn: PGConnection,
+        *,
+        topic_name: str,
+        routing_key: str,
+        partition_count: int,
+        retention_max_age_seconds: int,
+        max_rows_per_topic: int,
+        max_total_payload_bytes: int,
+        default_content_type_mime: Optional[str] = None,
+        priority: int,
+        payload: bytes,
+        content_type: Optional[str],
+        headers: Sequence[Tuple[str, bytes]],
+        payload_compression: int = 0,
+    ) -> PgQueueMessageHandle:
+        flush_pg_connection(conn)
+        old_autocommit = conn.autocommit
+        conn.autocommit = False
+        try:
+            handle = self._enqueue_message_in_transaction(
+                conn,
+                topic_name=topic_name,
+                routing_key=routing_key,
+                partition_count=partition_count,
+                retention_max_age_seconds=retention_max_age_seconds,
+                max_rows_per_topic=max_rows_per_topic,
+                max_total_payload_bytes=max_total_payload_bytes,
+                default_content_type_mime=default_content_type_mime,
+                priority=priority,
+                payload=payload,
+                content_type=content_type,
+                headers=headers,
+                payload_compression=payload_compression,
+            )
+            conn.commit()
+            return handle
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            restore_pg_connection_autocommit(conn, old_autocommit)
+
+    def enqueue_batch(
+        self,
+        conn: PGConnection,
+        items: Sequence[EnqueueBatchItem],
+        *,
+        partition_count: int,
+        retention_max_age_seconds: int,
+        max_rows_per_topic: int,
+        max_total_payload_bytes: int,
+        default_content_type_mime: Optional[str] = None,
+    ) -> List[PgQueueMessageHandle]:
+        """Enqueue many records in one PostgreSQL transaction (single commit)."""
+        if not items:
+            return []
+        flush_pg_connection(conn)
+        old_autocommit = conn.autocommit
+        conn.autocommit = False
+        try:
+            handles: List[PgQueueMessageHandle] = []
+            for it in items:
+                handles.append(
+                    self._enqueue_message_in_transaction(
+                        conn,
+                        topic_name=it.topic_name,
+                        routing_key=it.routing_key,
+                        partition_count=partition_count,
+                        retention_max_age_seconds=retention_max_age_seconds,
+                        max_rows_per_topic=max_rows_per_topic,
+                        max_total_payload_bytes=max_total_payload_bytes,
+                        default_content_type_mime=default_content_type_mime,
+                        priority=it.priority,
+                        payload=it.payload,
+                        content_type=it.content_type,
+                        headers=it.headers,
+                        payload_compression=it.payload_compression,
+                    )
+                )
+            conn.commit()
+            return handles
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            restore_pg_connection_autocommit(conn, old_autocommit)
+
+    def _receive_content_type_expr(self) -> str:
+        return (
+            f"(SELECT ct.mime FROM {self._content_type} ct WHERE ct.id = "
+            f"COALESCE(m.content_type_id, (SELECT t.default_content_type_id FROM "
+            f"{self._topic} t WHERE t.id = m.topic_id)))"
+        )
+
+    def _load_committed_offset(
+        self,
+        conn: PGConnection,
+        consumer_group: str,
+        topic_id: int,
+        partition_id: int,
+    ) -> int:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT offset_value FROM {self._consumer_offset}
+                WHERE consumer_group = %s AND topic_id = %s AND partition_id = %s
+                """,
+                (consumer_group, topic_id, partition_id),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return 0
+            return int(row[0])
+
+    def _load_max_enqueue_seq(
+        self, conn: PGConnection, topic_id: int, partition_id: int
+    ) -> int:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT COALESCE(MAX(enqueue_seq), 0) FROM {self._message}
+                WHERE topic_id = %s AND partition_id = %s
+                """,
+                (topic_id, partition_id),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return 0
+            return int(row[0])
+
+    def partition_max_enqueue_seqs(
+        self, conn: PGConnection, topic_id: int, partition_count: int
+    ) -> Dict[int, int]:
+        out: Dict[int, int] = {p: 0 for p in range(partition_count)}
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT partition_id, COALESCE(MAX(enqueue_seq), 0)
+                FROM {self._message}
+                WHERE topic_id = %s
+                GROUP BY partition_id
+                """,
+                (topic_id,),
+            )
+            for row in cur.fetchall():
+                out[int(row[0])] = int(row[1])
+        return out
+
+    def get_committed_offset(
+        self,
+        conn: PGConnection,
+        consumer_group: str,
+        topic_id: int,
+        partition_id: int,
+    ) -> int:
+        return self._load_committed_offset(conn, consumer_group, topic_id, partition_id)
+
+    def detect_offset_ahead_of_log(
+        self,
+        conn: PGConnection,
+        consumer_group: str,
+        topic_id: int,
+        partition_count: int,
+        *,
+        topic_name: Optional[str] = None,
+    ) -> List[PartitionOffsetSkew]:
+        max_seqs = self.partition_max_enqueue_seqs(conn, topic_id, partition_count)
+        skewed: List[PartitionOffsetSkew] = []
+        for p in range(partition_count):
+            max_seq = max_seqs.get(p, 0)
+            committed = self.get_committed_offset(conn, consumer_group, topic_id, p)
+            if committed > max_seq:
+                skewed.append(
+                    PartitionOffsetSkew(
+                        consumer_group=consumer_group,
+                        topic_id=topic_id,
+                        topic_name=topic_name,
+                        partition_id=p,
+                        committed_offset=committed,
+                        max_seq=max_seq,
+                        ahead_by=committed - max_seq,
+                    )
+                )
+        return skewed
+
+    def _select_candidate_handles_band(
+        self,
+        conn: PGConnection,
+        consumer_group: str,
+        topic_id: int,
+        partition_id: int,
+        min_exclusive_seq: int,
+        min_priority: int,
+        max_priority: int,
+        limit: int,
+    ) -> List[PgQueueMessageHandle]:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT m.id, m.enqueued_at, m.topic_id, m.partition_id, m.enqueue_seq
+                FROM {self._message} m
+                LEFT JOIN {self._lease} l
+                  ON l.message_id = m.id
+                 AND l.message_enqueued_at = m.enqueued_at
+                 AND l.consumer_group = %s
+                WHERE m.topic_id = %s AND m.partition_id = %s
+                  AND m.enqueue_seq > %s
+                  AND m.priority BETWEEN %s AND %s
+                  AND (l.id IS NULL OR l.locked_until < NOW())
+                ORDER BY m.priority ASC, m.enqueue_seq ASC
+                LIMIT %s
+                """,
+                (
+                    consumer_group,
+                    topic_id,
+                    partition_id,
+                    min_exclusive_seq,
+                    min_priority,
+                    max_priority,
+                    limit,
+                ),
+            )
+            rows = cur.fetchall()
+        return [
+            PgQueueMessageHandle(
+                id=int(r[0]),
+                enqueued_at=r[1],
+                topic_id=int(r[2]),
+                partition_id=int(r[3]),
+                enqueue_seq=int(r[4]),
+            )
+            for r in rows
+        ]
+
+    def _select_candidate_handles_for_group(
+        self,
+        conn: PGConnection,
+        consumer_group: str,
+        topic_id: int,
+        partition_id: int,
+        min_exclusive_seq: int,
+        candidate_limit: int,
+        band_config: PriorityBandConfig,
+    ) -> List[PgQueueMessageHandle]:
+        from datahub.pgqueue.priority_bands import weighted_fair_fetch
+
+        return weighted_fair_fetch(
+            band_config,
+            candidate_limit,
+            lambda min_p, max_p, band_limit: self._select_candidate_handles_band(
+                conn,
+                consumer_group,
+                topic_id,
+                partition_id,
+                min_exclusive_seq,
+                min_p,
+                max_p,
+                band_limit,
+            ),
+        )
+
+    def _try_acquire_lease_for_group(
+        self,
+        conn: PGConnection,
+        handle: PgQueueMessageHandle,
+        consumer_group: str,
+        lock_owner: str,
+        visibility_seconds: float,
+    ) -> bool:
+        lease = self._lease
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {lease}
+                  (message_id, message_enqueued_at, consumer_group, lock_owner, locked_until)
+                VALUES (%s, %s, %s, %s, NOW() + %s * INTERVAL '1 second')
+                ON CONFLICT (message_id, message_enqueued_at, consumer_group) DO UPDATE SET
+                  lock_owner = EXCLUDED.lock_owner,
+                  locked_until = EXCLUDED.locked_until
+                WHERE {lease}.locked_until < NOW()
+                RETURNING {lease}.message_id
+                """,
+                (
+                    handle.id,
+                    handle.enqueued_at,
+                    consumer_group,
+                    lock_owner,
+                    visibility_seconds,
+                ),
+            )
+            row = cur.fetchone()
+            return row is not None
+
+    def _load_received_message_row(
+        self,
+        conn: PGConnection,
+        handle: PgQueueMessageHandle,
+        lock_owner: str,
+    ) -> PgQueueReceivedMessage:
+        ctype_expr = self._receive_content_type_expr()
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT m.priority, m.payload, {ctype_expr} AS content_type,
+                       m.payload_compression, m.headers, m.routing_key
+                FROM {self._message} m
+                WHERE m.id = %s AND m.enqueued_at = %s
+                """,
+                (handle.id, handle.enqueued_at),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise RuntimeError(f"message row missing after lease: {handle}")
+        pc_raw = int(row[3]) if row[3] is not None else 0
+        hdrs = tuple(headers_from_db(row[4]))
+        rk = row[5] if row[5] is not None else ""
+        return PgQueueReceivedMessage(
+            handle=handle,
+            priority=int(row[0]),
+            payload=bytes(row[1]),
+            content_type=str(row[2]) if row[2] is not None else None,
+            payload_compression=pc_raw,
+            headers=hdrs,
+            routing_key=str(rk),
+            lock_owner=lock_owner,
+        )
+
+    def _receive_partition_for_group(
+        self,
+        conn: PGConnection,
+        consumer_group: str,
+        topic_id: int,
+        partition_id: int,
+        lock_owner: str,
+        visibility_seconds: float,
+        limit: int,
+        band_config: PriorityBandConfig,
+    ) -> List[PgQueueReceivedMessage]:
+        committed_offset = self._load_committed_offset(
+            conn, consumer_group, topic_id, partition_id
+        )
+        max_seq = self._load_max_enqueue_seq(conn, topic_id, partition_id)
+        if committed_offset > max_seq:
+            warn_if_ahead(
+                PartitionOffsetSkew(
+                    consumer_group=consumer_group,
+                    topic_id=topic_id,
+                    partition_id=partition_id,
+                    committed_offset=committed_offset,
+                    max_seq=max_seq,
+                    ahead_by=committed_offset - max_seq,
+                )
+            )
+        out: List[PgQueueReceivedMessage] = []
+        safety = 0
+        max_rounds = max(50, limit * 10)
+        while len(out) < limit and safety < max_rounds:
+            safety += 1
+            candidates = self._select_candidate_handles_for_group(
+                conn,
+                consumer_group,
+                topic_id,
+                partition_id,
+                committed_offset,
+                max(limit * 2, 8),
+                band_config,
+            )
+            if not candidates:
+                break
+            progressed = False
+            for h in candidates:
+                if len(out) >= limit:
+                    break
+                if self._try_acquire_lease_for_group(
+                    conn, h, consumer_group, lock_owner, visibility_seconds
+                ):
+                    out.append(self._load_received_message_row(conn, h, lock_owner))
+                    progressed = True
+            if not progressed:
+                break
+        return out
+
+    def receive_batch_for_group(
+        self,
+        conn: PGConnection,
+        *,
+        consumer_group: str,
+        topic_id: int,
+        partition_ids: Sequence[int],
+        lock_owner: str,
+        visibility_timeout: timedelta,
+        max_messages: int,
+        priority_bands_json: str = DEFAULT_BANDS_JSON,
+    ) -> List[PgQueueReceivedMessage]:
+        """Poll partitions in one transaction; acquire work via ``message_group_lease`` only."""
+        if max_messages <= 0 or not partition_ids:
+            return []
+
+        band_config = PriorityBandConfig.parse(priority_bands_json)
+        flush_pg_connection(conn)
+        old_autocommit = conn.autocommit
+        conn.autocommit = False
+        try:
+            vis_secs = visibility_timeout.total_seconds()
+            combined: List[PgQueueReceivedMessage] = []
+            remaining = max_messages
+            for pid in partition_ids:
+                if remaining <= 0:
+                    break
+                batch = self._receive_partition_for_group(
+                    conn,
+                    consumer_group,
+                    topic_id,
+                    int(pid),
+                    lock_owner,
+                    vis_secs,
+                    remaining,
+                    band_config,
+                )
+                combined.extend(batch)
+                remaining = max_messages - len(combined)
+            conn.commit()
+            return combined
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            restore_pg_connection_autocommit(conn, old_autocommit)
+
+    def commit_for_group(
+        self,
+        conn: PGConnection,
+        consumer_group: str,
+        handles: Sequence[PgQueueMessageHandle],
+    ) -> int:
+        """Delete group leases and advance committed offsets (max ``enqueue_seq`` per partition)."""
+        if not handles:
+            return 0
+        flush_pg_connection(conn)
+        old_autocommit = conn.autocommit
+        conn.autocommit = False
+        try:
+            with conn.cursor() as cur:
+                placeholders = ", ".join(["(%s, %s::timestamptz)"] * len(handles))
+                delete_params: List[Any] = [consumer_group]
+                for h in handles:
+                    delete_params.extend([h.id, h.enqueued_at])
+                cur.execute(
+                    f"""
+                    DELETE FROM {self._lease}
+                    WHERE consumer_group = %s
+                      AND (message_id, message_enqueued_at) IN ({placeholders})
+                    """,
+                    tuple(delete_params),
+                )
+                deleted = cur.rowcount
+
+                max_seq: Dict[int, Dict[int, int]] = defaultdict(dict)
+                for h in handles:
+                    part_map = max_seq[h.topic_id]
+                    prev = part_map.get(h.partition_id)
+                    part_map[h.partition_id] = (
+                        h.enqueue_seq if prev is None else max(prev, h.enqueue_seq)
+                    )
+                for tid, pmap in max_seq.items():
+                    for part_id, seq in pmap.items():
+                        cur.execute(
+                            f"""
+                            INSERT INTO {self._consumer_offset} AS co
+                              (consumer_group, topic_id, partition_id, offset_value, epoch)
+                            VALUES (%s, %s, %s, %s, 0)
+                            ON CONFLICT (consumer_group, topic_id, partition_id)
+                            DO UPDATE SET offset_value = GREATEST(
+                                co.offset_value, EXCLUDED.offset_value
+                            )
+                            """,
+                            (consumer_group, tid, part_id, seq),
+                        )
+            conn.commit()
+            return int(deleted)
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            restore_pg_connection_autocommit(conn, old_autocommit)
+
+    def extend_visibility_for_group(
+        self,
+        conn: PGConnection,
+        consumer_group: str,
+        handles: Collection[PgQueueMessageHandle],
+        *,
+        lock_owner: str,
+        extend_by: timedelta,
+    ) -> int:
+        """Extend ``locked_until`` on lease rows for this group and ``lock_owner``."""
+        if not handles:
+            return 0
+        handle_list = list(handles)
+        secs = extend_by.total_seconds()
+        flush_pg_connection(conn)
+        old_autocommit = conn.autocommit
+        conn.autocommit = False
+        try:
+            with conn.cursor() as cur:
+                values_sql = ", ".join(["(%s, %s::timestamptz)"] * len(handle_list))
+                params: List[Any] = [secs]
+                for h in handle_list:
+                    params.extend([h.id, h.enqueued_at])
+                params.extend([consumer_group, lock_owner])
+                cur.execute(
+                    f"""
+                    UPDATE {self._lease} AS l
+                    SET locked_until = NOW() + %s * INTERVAL '1 second'
+                    FROM (VALUES {values_sql}) AS v(id, enqueued_at)
+                    WHERE l.message_id = v.id
+                      AND l.message_enqueued_at = v.enqueued_at
+                      AND l.consumer_group = %s
+                      AND l.lock_owner = %s
+                    """,
+                    tuple(params),
+                )
+                updated = cur.rowcount
+            conn.commit()
+            return int(updated)
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            restore_pg_connection_autocommit(conn, old_autocommit)
+
+    def register_consumer(
+        self,
+        conn: PGConnection,
+        consumer_group: str,
+        topic_id: int,
+    ) -> None:
+        """Upsert a consumer registration row (heartbeat updates ``last_heartbeat_at``)."""
+        flush_pg_connection(conn)
+        old_autocommit = conn.autocommit
+        conn.autocommit = False
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    INSERT INTO {self._consumer_registration}
+                      (consumer_group, topic_id)
+                    VALUES (%s, %s)
+                    ON CONFLICT (consumer_group, topic_id)
+                    DO UPDATE SET last_heartbeat_at = NOW()
+                    """,
+                    (consumer_group, topic_id),
+                )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            restore_pg_connection_autocommit(conn, old_autocommit)

--- a/metadata-ingestion/src/datahub/pgqueue/sql.py
+++ b/metadata-ingestion/src/datahub/pgqueue/sql.py
@@ -1,0 +1,30 @@
+"""Helpers for safely quoting PostgreSQL identifiers used in pgQueue paths."""
+
+from __future__ import annotations
+
+import re
+
+_IDENTIFIER_UNQUOTED = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def validate_pg_identifier(name: str, field_name: str) -> str:
+    """Restrict schema/table identifiers to unquoted-safe tokens."""
+    if not _IDENTIFIER_UNQUOTED.fullmatch(name):
+        raise ValueError(
+            f"{field_name} must match {_IDENTIFIER_UNQUOTED.pattern} (got {name!r})"
+        )
+    return name
+
+
+def quote_ident(ident: str) -> str:
+    """Quote a PostgreSQL identifier (duplicate internal double-quotes)."""
+    validate_pg_identifier(ident, "identifier")
+    return '"' + ident.replace('"', '""') + '"'
+
+
+def qualified_table(schema: str, table_prefix: str, suffix: str) -> str:
+    """Return `"schema"."prefix_suffix"` for DDL-derived table names."""
+    validate_pg_identifier(schema, "schema")
+    validate_pg_identifier(table_prefix, "table_prefix")
+    validate_pg_identifier(suffix, "suffix")
+    return f"{quote_ident(schema)}.{quote_ident(f'{table_prefix}_{suffix}')}"

--- a/metadata-ingestion/tests/integration/pgqueue/test_pgqueue_optional_it.py
+++ b/metadata-ingestion/tests/integration/pgqueue/test_pgqueue_optional_it.py
@@ -1,0 +1,22 @@
+"""
+Placeholder for future Docker-backed pgQueue integration tests.
+
+PgQueue DDL requires ``pg_partman`` (see ``datahub-upgrade/.../sqlsetup/pgqueue``).
+Unit coverage lives under ``tests/unit/pgqueue/``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.skip(
+    reason=(
+        "Automated pgQueue IT requires Postgres with pg_partman + SqlSetup DDL; "
+        "not wired in CI yet."
+    )
+)
+def test_pgqueue_live_database_placeholder() -> None:
+    raise AssertionError("unreachable")

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_compression.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_compression.py
@@ -1,0 +1,50 @@
+"""Unit tests for :mod:`datahub.pgqueue.compression` codec helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from datahub.pgqueue.compression import (
+    PgQueuePayloadCompression,
+    decode_stored,
+    encode_inner,
+    from_wire,
+)
+
+
+class TestFromWire:
+    def test_zero_returns_none(self) -> None:
+        assert from_wire(0) is PgQueuePayloadCompression.NONE
+
+    def test_one_returns_snappy(self) -> None:
+        assert from_wire(1) is PgQueuePayloadCompression.SNAPPY
+
+    def test_unknown_code_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported"):
+            from_wire(99)
+
+
+class TestRoundTrip:
+    _SAMPLE = b'{"urn":"urn:li:dataset:(urn:li:dataPlatform:pg,db.tbl,PROD)"}'
+
+    def test_none_mode_data_unchanged(self) -> None:
+        encoded = encode_inner(self._SAMPLE, PgQueuePayloadCompression.NONE)
+        assert encoded == self._SAMPLE
+        assert decode_stored(encoded, PgQueuePayloadCompression.NONE) == self._SAMPLE
+
+    def test_snappy_mode_round_trip(self) -> None:
+        encoded = encode_inner(self._SAMPLE, PgQueuePayloadCompression.SNAPPY)
+        assert decode_stored(encoded, PgQueuePayloadCompression.SNAPPY) == self._SAMPLE
+
+    def test_snappy_produces_different_output(self) -> None:
+        encoded = encode_inner(self._SAMPLE, PgQueuePayloadCompression.SNAPPY)
+        assert encoded != self._SAMPLE
+
+    def test_empty_bytes_round_trip_none(self) -> None:
+        encoded = encode_inner(b"", PgQueuePayloadCompression.NONE)
+        assert encoded == b""
+        assert decode_stored(encoded, PgQueuePayloadCompression.NONE) == b""
+
+    def test_empty_bytes_round_trip_snappy(self) -> None:
+        encoded = encode_inner(b"", PgQueuePayloadCompression.SNAPPY)
+        assert decode_stored(encoded, PgQueuePayloadCompression.SNAPPY) == b""

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_config.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_config.py
@@ -1,0 +1,57 @@
+import pytest
+from pydantic import ValidationError
+
+from datahub.pgqueue.config import PgQueueAuthMode, PgQueueConnectionConfig
+
+
+def test_password_mode_requires_secret() -> None:
+    with pytest.raises(ValidationError):
+        PgQueueConnectionConfig(
+            host_port="localhost:5432",
+            database="db",
+            username="u",
+            auth_mode=PgQueueAuthMode.PASSWORD,
+        )
+
+
+def test_iam_requires_colon_port() -> None:
+    with pytest.raises(ValidationError):
+        PgQueueConnectionConfig(
+            host_port="localhost",
+            database="db",
+            username="u",
+            auth_mode=PgQueueAuthMode.AWS_IAM,
+        )
+
+
+def test_password_mode_ok() -> None:
+    PgQueueConnectionConfig(
+        host_port="localhost:5432",
+        database="db",
+        username="u",
+        password="secret",
+        auth_mode=PgQueueAuthMode.PASSWORD,
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("queue_schema", "queue;drop"),
+        ("queue_schema", ""),
+        ("queue_schema", "has space"),
+        ("table_prefix", "prefix--bad"),
+        ("table_prefix", "1starts_with_digit"),
+    ],
+)
+def test_rejects_unsafe_sql_identifiers(field: str, value: str) -> None:
+    kwargs = {
+        "host_port": "localhost:5432",
+        "database": "db",
+        "username": "u",
+        "password": "secret",
+        "auth_mode": PgQueueAuthMode.PASSWORD,
+        field: value,
+    }
+    with pytest.raises(ValidationError):
+        PgQueueConnectionConfig(**kwargs)

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_config_topic_overrides.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_config_topic_overrides.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datahub.pgqueue.config import (
+    PgQueueConnectionConfig,
+    PgQueueTopicPartialConfig,
+)
+
+
+def test_merged_topic_defaults_for_applies_override_by_topic_name() -> None:
+    queue = PgQueueConnectionConfig(
+        host_port="localhost:5432",
+        database="d",
+        username="u",
+        password="p",
+        topic_overrides={
+            "MetadataChangeLog_Timeseries_v1": PgQueueTopicPartialConfig(
+                retention_max_age_seconds=7776000,
+            ),
+        },
+    )
+    merged = queue.merged_topic_defaults_for("MetadataChangeLog_Timeseries_v1")
+    assert merged.retention_max_age_seconds == 7776000
+
+    base_only = queue.merged_topic_defaults_for("Other_v1")
+    assert (
+        base_only.retention_max_age_seconds
+        == queue.topic_defaults.retention_max_age_seconds
+    )

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_connection_flush.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_connection_flush.py
@@ -1,0 +1,77 @@
+"""Tests for pgQueue connection flush / autocommit coordination."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+psycopg2_extensions = pytest.importorskip("psycopg2.extensions")
+
+from datahub.pgqueue.connection import (  # noqa: E402
+    flush_pg_connection,
+    restore_pg_connection_autocommit,
+)
+
+
+def test_flush_pg_connection_skips_when_closed() -> None:
+    conn = MagicMock()
+    conn.closed = 1
+    flush_pg_connection(conn)
+    conn.get_transaction_status.assert_not_called()
+
+
+def test_flush_pg_connection_rollbacks_inerror() -> None:
+    conn = MagicMock()
+    conn.closed = 0
+    conn.get_transaction_status.return_value = (
+        psycopg2_extensions.TRANSACTION_STATUS_INERROR
+    )
+    flush_pg_connection(conn)
+    conn.rollback.assert_called_once()
+    conn.commit.assert_not_called()
+
+
+def test_flush_pg_connection_commits_intrans() -> None:
+    conn = MagicMock()
+    conn.closed = 0
+    conn.get_transaction_status.return_value = (
+        psycopg2_extensions.TRANSACTION_STATUS_INTRANS
+    )
+    flush_pg_connection(conn)
+    conn.commit.assert_called_once()
+    conn.rollback.assert_not_called()
+
+
+def test_flush_pg_connection_noop_when_idle() -> None:
+    conn = MagicMock()
+    conn.closed = 0
+    conn.get_transaction_status.return_value = (
+        psycopg2_extensions.TRANSACTION_STATUS_IDLE
+    )
+    flush_pg_connection(conn)
+    conn.commit.assert_not_called()
+    conn.rollback.assert_not_called()
+
+
+def test_restore_pg_connection_autocommit_rollbacks_failed_txn_first() -> None:
+    conn = MagicMock()
+    conn.get_transaction_status.return_value = (
+        psycopg2_extensions.TRANSACTION_STATUS_INERROR
+    )
+    restore_pg_connection_autocommit(conn, True)
+    conn.rollback.assert_called_once()
+
+
+def test_flush_pg_connection_rollback_after_failed_commit() -> None:
+    conn = MagicMock()
+    conn.closed = 0
+    conn.get_transaction_status.return_value = (
+        psycopg2_extensions.TRANSACTION_STATUS_INTRANS
+    )
+    conn.commit.side_effect = RuntimeError("commit failed")
+
+    flush_pg_connection(conn)
+
+    conn.commit.assert_called_once()
+    conn.rollback.assert_called_once()

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_connection_kwargs.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_connection_kwargs.py
@@ -1,0 +1,76 @@
+"""Unit tests for :func:`datahub.pgqueue.connection.build_psycopg2_connect_kwargs`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub.pgqueue.config import PgQueueAuthMode, PgQueueConnectionConfig
+from datahub.pgqueue.connection import build_psycopg2_connect_kwargs
+
+
+def _make_config(**overrides: object) -> PgQueueConnectionConfig:
+    defaults: dict[str, object] = dict(
+        host_port="pg.example.com:5432",
+        database="datahub",
+        username="dh_user",
+        password="s3cret",
+    )
+    defaults.update(overrides)
+    return PgQueueConnectionConfig(**defaults)
+
+
+class TestPasswordMode:
+    def test_basic_kwargs(self) -> None:
+        cfg = _make_config()
+        kwargs = build_psycopg2_connect_kwargs(cfg)
+
+        assert kwargs["host"] == "pg.example.com"
+        assert kwargs["port"] == 5432
+        assert kwargs["dbname"] == "datahub"
+        assert kwargs["user"] == "dh_user"
+        assert kwargs["password"] == "s3cret"
+        assert kwargs["sslmode"] == "prefer"
+        assert kwargs["connect_timeout"] == 60
+
+    def test_sslmode_propagated(self) -> None:
+        cfg = _make_config(sslmode="require")
+        kwargs = build_psycopg2_connect_kwargs(cfg)
+        assert kwargs["sslmode"] == "require"
+
+    def test_custom_connect_timeout(self) -> None:
+        cfg = _make_config(connect_timeout_seconds=10)
+        kwargs = build_psycopg2_connect_kwargs(cfg)
+        assert kwargs["connect_timeout"] == 10
+
+
+class TestPortParsing:
+    def test_missing_port_uses_default(self) -> None:
+        cfg = _make_config(host_port="pg.example.com")
+        kwargs = build_psycopg2_connect_kwargs(cfg)
+        assert kwargs["host"] == "pg.example.com"
+        assert kwargs["port"] == 5432
+
+    def test_non_numeric_port_rejected_by_config(self) -> None:
+        with pytest.raises(Exception, match="port"):
+            _make_config(host_port="pg.example.com:abc")
+
+
+class TestAwsIamMode:
+    @patch("datahub.ingestion.source.aws.aws_common.RDSIAMTokenManager")
+    def test_builds_iam_token_and_requires_ssl(self, token_mgr_cls: MagicMock) -> None:
+        token_mgr_cls.return_value.get_token.return_value = "iam-token-xyz"
+        cfg = PgQueueConnectionConfig(
+            host_port="mydb.us-east-1.rds.amazonaws.com:5432",
+            database="datahub",
+            username="dh_user",
+            auth_mode=PgQueueAuthMode.AWS_IAM,
+            aws_config={"aws_region": "us-east-1"},
+        )
+
+        kwargs = build_psycopg2_connect_kwargs(cfg)
+
+        assert kwargs["password"] == "iam-token-xyz"
+        assert kwargs["sslmode"] == "require"
+        token_mgr_cls.assert_called_once()

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_consumer_core.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_consumer_core.py
@@ -1,0 +1,268 @@
+"""Unit tests for :mod:`datahub.pgqueue.consumer` core behaviour (no database)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub.emitter.kafka_emitter import MCE_KEY, MCP_KEY
+from datahub.metadata.schema_classes import (
+    MetadataChangeEventClass as MetadataChangeEvent,
+    MetadataChangeLogClass,
+    MetadataChangeProposalClass as MetadataChangeProposal,
+)
+from datahub.pgqueue.config import PgQueueConnectionConfig, PgQueueConsumerConfig
+from datahub.pgqueue.repository import PgQueueMessageHandle
+
+
+def _make_consumer_config(
+    visibility_override: int | None = None,
+) -> PgQueueConsumerConfig:
+    return PgQueueConsumerConfig(
+        queue=PgQueueConnectionConfig(
+            host_port="localhost:5432",
+            database="datahub",
+            username="pguser",
+            password="secret",
+        ),
+        schema_registry_url="http://localhost:8081",
+        consumer_group="test-group",
+        visibility_timeout_seconds=visibility_override,
+    )
+
+
+# ---------------------------------------------------------------------------
+# visibility_timedelta
+# ---------------------------------------------------------------------------
+
+
+class TestVisibilityTimedelta:
+    @patch("datahub.pgqueue.consumer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.consumer.SchemaRegistryClient")
+    @patch("datahub.pgqueue.consumer.AvroDeserializer")
+    def test_uses_config_override_when_set(
+        self,
+        _deser_cls: MagicMock,
+        _sr_cls: MagicMock,
+        _conn_fn: MagicMock,
+    ) -> None:
+        from datahub.pgqueue.consumer import DatahubPgQueueConsumer
+
+        cfg = _make_consumer_config(visibility_override=120)
+        consumer = DatahubPgQueueConsumer(cfg)
+        assert consumer.visibility_timedelta() == timedelta(seconds=120)
+
+    @patch("datahub.pgqueue.consumer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.consumer.SchemaRegistryClient")
+    @patch("datahub.pgqueue.consumer.AvroDeserializer")
+    def test_falls_back_to_topic_defaults(
+        self,
+        _deser_cls: MagicMock,
+        _sr_cls: MagicMock,
+        _conn_fn: MagicMock,
+    ) -> None:
+        from datahub.pgqueue.consumer import DatahubPgQueueConsumer
+
+        cfg = _make_consumer_config(visibility_override=None)
+        expected = cfg.queue.topic_defaults.visibility_timeout_seconds
+        consumer = DatahubPgQueueConsumer(cfg)
+        assert consumer.visibility_timedelta() == timedelta(seconds=expected)
+
+
+# ---------------------------------------------------------------------------
+# _deserialize
+# ---------------------------------------------------------------------------
+
+
+class TestDeserialize:
+    """Patch the AvroDeserializer and verify each payload-kind branch."""
+
+    @patch("datahub.pgqueue.consumer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.consumer.SchemaRegistryClient")
+    @patch("datahub.pgqueue.consumer.AvroDeserializer")
+    def _build_consumer(
+        self,
+        _deser_cls: MagicMock,
+        _sr_cls: MagicMock,
+        _conn_fn: MagicMock,
+        payload_kinds: dict | None = None,
+    ) -> tuple:
+        from datahub.pgqueue.consumer import DatahubPgQueueConsumer
+
+        cfg = _make_consumer_config()
+        if payload_kinds:
+            cfg = cfg.model_copy(update={"payload_kind_by_route_key": payload_kinds})
+        consumer = DatahubPgQueueConsumer(cfg)
+        return consumer, consumer._avro_deserializer
+
+    def test_mcp_branch(self) -> None:
+        consumer, mock_deser = self._build_consumer()
+        mock_deser.return_value = {
+            "entityUrn": "urn:li:dataset:foo",
+            "entityType": "dataset",
+            "changeType": "UPSERT",
+        }
+
+        result = consumer._deserialize(MCP_KEY, "MetadataChangeProposal_v1", b"\x00")
+        assert isinstance(result, MetadataChangeProposal)
+
+    def test_mce_branch(self) -> None:
+        consumer, mock_deser = self._build_consumer()
+        mock_deser.return_value = {
+            "proposedSnapshot": (
+                "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot",
+                {
+                    "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,db.tbl,PROD)",
+                    "aspects": [],
+                },
+            )
+        }
+
+        result = consumer._deserialize(MCE_KEY, "MetadataChangeEvent_v4", b"\x00")
+        assert isinstance(result, MetadataChangeEvent)
+
+    def test_mcl_branch(self) -> None:
+        consumer, mock_deser = self._build_consumer(
+            payload_kinds={MCP_KEY: "mcp", MCE_KEY: "mce", "mcl_route": "mcl"},
+        )
+        mock_deser.return_value = {
+            "entityUrn": "urn:li:dataset:foo",
+            "entityType": "dataset",
+            "changeType": "UPSERT",
+            "aspectName": "ownership",
+        }
+
+        result = consumer._deserialize("mcl_route", "MetadataChangeLog_v1", b"\x00")
+        assert isinstance(result, MetadataChangeLogClass)
+
+    def test_pe_branch(self) -> None:
+        consumer, mock_deser = self._build_consumer(
+            payload_kinds={MCP_KEY: "mcp", "pe_route": "pe"},
+        )
+        raw_dict = {"entityUrn": "urn:li:dataset:bar", "eventType": "usage"}
+        mock_deser.return_value = raw_dict
+
+        result = consumer._deserialize("pe_route", "PlatformEvent_v1", b"\x00")
+        assert isinstance(result, dict)
+        assert result == raw_dict
+
+    def test_unsupported_kind_raises(self) -> None:
+        consumer, mock_deser = self._build_consumer(
+            payload_kinds={MCP_KEY: "mcp", "bad_route": "unknown"},  # type: ignore[dict-item]
+        )
+        mock_deser.return_value = {}
+
+        with pytest.raises(ValueError, match="Unsupported payload kind"):
+            consumer._deserialize("bad_route", "SomeTopic_v1", b"\x00")
+
+
+# ---------------------------------------------------------------------------
+# ack
+# ---------------------------------------------------------------------------
+
+
+class TestAck:
+    @patch("datahub.pgqueue.consumer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.consumer.SchemaRegistryClient")
+    @patch("datahub.pgqueue.consumer.AvroDeserializer")
+    def test_delegates_to_repo(
+        self,
+        _deser_cls: MagicMock,
+        _sr_cls: MagicMock,
+        _conn_fn: MagicMock,
+    ) -> None:
+        from datetime import datetime, timezone
+
+        from datahub.pgqueue.consumer import DatahubPgQueueConsumer
+
+        cfg = _make_consumer_config()
+        consumer = DatahubPgQueueConsumer(cfg)
+
+        handles = [
+            PgQueueMessageHandle(
+                id=1,
+                enqueued_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                topic_id=10,
+                partition_id=0,
+                enqueue_seq=42,
+            ),
+        ]
+
+        with patch.object(consumer, "_repo") as mock_repo:
+            mock_repo.commit_for_group.return_value = 1
+            result = consumer.ack(handles)
+
+        mock_repo.commit_for_group.assert_called_once_with(
+            consumer._conn,
+            cfg.consumer_group,
+            handles,
+        )
+        assert result == 1
+
+
+class TestExtendVisibility:
+    @patch("datahub.pgqueue.consumer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.consumer.SchemaRegistryClient")
+    @patch("datahub.pgqueue.consumer.AvroDeserializer")
+    def test_delegates_to_repo(
+        self,
+        _deser_cls: MagicMock,
+        _sr_cls: MagicMock,
+        _conn_fn: MagicMock,
+    ) -> None:
+        from datetime import datetime, timedelta, timezone
+
+        from datahub.pgqueue.consumer import DatahubPgQueueConsumer
+
+        cfg = _make_consumer_config()
+        consumer = DatahubPgQueueConsumer(cfg)
+        handles = [
+            PgQueueMessageHandle(
+                id=3,
+                enqueued_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                topic_id=10,
+                partition_id=1,
+                enqueue_seq=9,
+            ),
+        ]
+
+        with patch.object(consumer, "_repo") as mock_repo:
+            mock_repo.extend_visibility_for_group.return_value = 1
+            result = consumer.extend_visibility(
+                handles, extend_by=timedelta(seconds=30)
+            )
+
+        mock_repo.extend_visibility_for_group.assert_called_once_with(
+            consumer._conn,
+            cfg.consumer_group,
+            handles,
+            lock_owner=consumer._lock_owner,
+            extend_by=timedelta(seconds=30),
+        )
+        assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# close
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    @patch("datahub.pgqueue.consumer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.consumer.SchemaRegistryClient")
+    @patch("datahub.pgqueue.consumer.AvroDeserializer")
+    def test_closes_connection(
+        self,
+        _deser_cls: MagicMock,
+        _sr_cls: MagicMock,
+        conn_fn: MagicMock,
+    ) -> None:
+        from datahub.pgqueue.consumer import DatahubPgQueueConsumer
+
+        cfg = _make_consumer_config()
+        consumer = DatahubPgQueueConsumer(cfg)
+
+        consumer.close()
+        consumer._conn.close.assert_called_once()

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_consumer_poll_route_keys.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_consumer_poll_route_keys.py
@@ -1,0 +1,37 @@
+"""Tests for :meth:`DatahubPgQueueConsumer.poll_route_keys`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+from datahub.pgqueue.config import PgQueueConnectionConfig, PgQueueConsumerConfig
+from datahub.pgqueue.consumer import DatahubPgQueueConsumer
+
+
+def test_poll_route_keys_delegates_to_poll_route_key() -> None:
+    queue_cfg = PgQueueConnectionConfig(
+        host_port="localhost:5432",
+        database="db",
+        username="u",
+        password="secret",
+    )
+    cfg = PgQueueConsumerConfig(queue=queue_cfg)
+    side_a = [MagicMock(name="a")]
+    side_b = [MagicMock(name="b")]
+    with (
+        patch("datahub.pgqueue.consumer.SchemaRegistryClient"),
+        patch("datahub.pgqueue.consumer.create_pgqueue_connection"),
+        patch.object(
+            DatahubPgQueueConsumer,
+            "poll_route_key",
+            side_effect=[side_a, side_b],
+        ) as poll_mock,
+    ):
+        consumer = DatahubPgQueueConsumer(cfg)
+        out = consumer.poll_route_keys(["mcp", "mce"], max_messages=7)
+
+    assert out == side_a + side_b
+    assert poll_mock.call_args_list == [
+        call("mcp", max_messages=7, partition_ids=None),
+        call("mce", max_messages=7, partition_ids=None),
+    ]

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_emitter.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_emitter.py
@@ -1,0 +1,270 @@
+"""Unit tests for :mod:`datahub.pgqueue.emitter` (no database, no Schema Registry)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub.emitter.kafka_emitter import MCP_KEY
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    MetadataChangeEventClass as MetadataChangeEvent,
+    MetadataChangeProposalClass as MetadataChangeProposal,
+)
+from datahub.pgqueue.config import PgQueueConnectionConfig, PgQueueEmitterConfig
+
+
+def _make_config() -> PgQueueEmitterConfig:
+    return PgQueueEmitterConfig(
+        queue=PgQueueConnectionConfig(
+            host_port="localhost:5432",
+            database="datahub",
+            username="pguser",
+            password="secret",
+        ),
+        schema_registry_url="http://localhost:8081",
+    )
+
+
+@pytest.fixture()
+def emitter_config() -> PgQueueEmitterConfig:
+    return _make_config()
+
+
+# ---------------------------------------------------------------------------
+# _serialize_for_enqueue
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeForEnqueue:
+    """Bypass __init__ side-effects (SR client, DB conn) by patching them out."""
+
+    @patch("datahub.pgqueue.emitter.create_pgqueue_connection")
+    @patch("datahub.pgqueue.emitter.AvroSerializer")
+    @patch("datahub.pgqueue.emitter.SchemaRegistryClient")
+    def test_mcp_with_urn(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        emitter_config: PgQueueEmitterConfig,
+    ) -> None:
+        fake_serializer = MagicMock(return_value=b"\x00payload")
+        avro_ser_cls.return_value = fake_serializer
+
+        from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+        emitter = DatahubPgQueueEmitter(emitter_config)
+
+        mcp = MetadataChangeProposalWrapper(
+            entityUrn="urn:li:dataset:(urn:li:dataPlatform:postgres,db.tbl,PROD)",
+            aspect=None,
+        )
+        topic, key, payload = emitter._serialize_for_enqueue(mcp)
+
+        assert topic == emitter_config.topic_routes[MCP_KEY]
+        assert key == mcp.entityUrn
+        assert payload == b"\x00payload"
+
+    @patch("datahub.pgqueue.emitter.create_pgqueue_connection")
+    @patch("datahub.pgqueue.emitter.AvroSerializer")
+    @patch("datahub.pgqueue.emitter.SchemaRegistryClient")
+    def test_mce_with_snapshot(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        emitter_config: PgQueueEmitterConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"\x00mce")
+
+        from datahub.emitter.kafka_emitter import MCE_KEY
+        from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+        emitter = DatahubPgQueueEmitter(emitter_config)
+
+        mce = MagicMock(spec=MetadataChangeEvent)
+        mce.proposedSnapshot = MagicMock()
+        mce.proposedSnapshot.urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:mysql,db.tbl,PROD)"
+        )
+
+        topic, key, payload = emitter._serialize_for_enqueue(mce)
+
+        assert topic == emitter_config.topic_routes[MCE_KEY]
+        assert key == mce.proposedSnapshot.urn
+        assert payload == b"\x00mce"
+
+    @patch("datahub.pgqueue.emitter.create_pgqueue_connection")
+    @patch("datahub.pgqueue.emitter.AvroSerializer")
+    @patch("datahub.pgqueue.emitter.SchemaRegistryClient")
+    def test_mcp_missing_urn_raises(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        emitter_config: PgQueueEmitterConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"x")
+
+        from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+        emitter = DatahubPgQueueEmitter(emitter_config)
+
+        mcp = MetadataChangeProposal(entityType="dataset", changeType="UPSERT")
+        assert mcp.entityUrn is None
+        with pytest.raises(ValueError, match="entityUrn"):
+            emitter._serialize_for_enqueue(mcp)
+
+    @patch("datahub.pgqueue.emitter.create_pgqueue_connection")
+    @patch("datahub.pgqueue.emitter.AvroSerializer")
+    @patch("datahub.pgqueue.emitter.SchemaRegistryClient")
+    def test_mce_missing_snapshot_raises(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        emitter_config: PgQueueEmitterConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"x")
+
+        from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+        emitter = DatahubPgQueueEmitter(emitter_config)
+
+        mce = MagicMock(spec=MetadataChangeEvent)
+        mce.proposedSnapshot = None
+
+        with pytest.raises(AttributeError):
+            emitter._serialize_for_enqueue(mce)
+
+
+# ---------------------------------------------------------------------------
+# emit (single)
+# ---------------------------------------------------------------------------
+
+
+class TestEmit:
+    @patch("datahub.pgqueue.emitter.create_pgqueue_connection")
+    @patch("datahub.pgqueue.emitter.AvroSerializer")
+    @patch("datahub.pgqueue.emitter.SchemaRegistryClient")
+    def test_emit_happy_path(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        conn_fn: MagicMock,
+        emitter_config: PgQueueEmitterConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"\x00avro")
+
+        from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+        emitter = DatahubPgQueueEmitter(emitter_config)
+
+        mcp = MetadataChangeProposalWrapper(
+            entityUrn="urn:li:dataset:(urn:li:dataPlatform:postgres,db.tbl,PROD)",
+            aspect=None,
+        )
+
+        with patch.object(emitter, "_repo") as mock_repo:
+            callback = MagicMock()
+            emitter.emit(mcp, callback=callback)
+
+            mock_repo.enqueue.assert_called_once()
+            callback.assert_called_once()
+            assert callback.call_args[0][0] is None  # no error
+
+
+# ---------------------------------------------------------------------------
+# emit_batch
+# ---------------------------------------------------------------------------
+
+
+class TestEmitBatch:
+    @patch("datahub.pgqueue.emitter.create_pgqueue_connection")
+    @patch("datahub.pgqueue.emitter.AvroSerializer")
+    @patch("datahub.pgqueue.emitter.SchemaRegistryClient")
+    def test_emit_batch_happy_path(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        emitter_config: PgQueueEmitterConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"\x00avro")
+
+        from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+        emitter = DatahubPgQueueEmitter(emitter_config)
+
+        items = [
+            MetadataChangeProposalWrapper(
+                entityUrn=f"urn:li:dataset:(urn:li:dataPlatform:postgres,db.tbl{i},PROD)",
+                aspect=None,
+            )
+            for i in range(3)
+        ]
+
+        with patch.object(emitter, "_repo") as mock_repo:
+            callback = MagicMock()
+            emitter.emit_batch(items, callback=callback)
+
+            mock_repo.enqueue_batch.assert_called_once()
+            assert callback.call_count == 3
+
+    @patch("datahub.pgqueue.emitter.create_pgqueue_connection")
+    @patch("datahub.pgqueue.emitter.AvroSerializer")
+    @patch("datahub.pgqueue.emitter.SchemaRegistryClient")
+    def test_emit_batch_mixed_topics_raises(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+    ) -> None:
+        """MCPs and MCEs in the same batch target different topics → ValueError."""
+        avro_ser_cls.return_value = MagicMock(return_value=b"\x00avro")
+
+        config = _make_config()
+        from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+        emitter = DatahubPgQueueEmitter(config)
+
+        mcp = MetadataChangeProposalWrapper(
+            entityUrn="urn:li:dataset:(urn:li:dataPlatform:postgres,db.tbl,PROD)",
+            aspect=None,
+        )
+        mce = MagicMock(spec=MetadataChangeEvent)
+        mce.proposedSnapshot = MagicMock()
+        mce.proposedSnapshot.urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:mysql,db.tbl,PROD)"
+        )
+
+        callback = MagicMock()
+        emitter.emit_batch([mcp, mce], callback=callback)
+
+        # The error is caught internally and forwarded to the callback
+        assert callback.call_count == 1
+        err = callback.call_args[0][0]
+        assert isinstance(err, ValueError)
+        assert "single topic" in str(err)
+
+    @patch("datahub.pgqueue.emitter.create_pgqueue_connection")
+    @patch("datahub.pgqueue.emitter.AvroSerializer")
+    @patch("datahub.pgqueue.emitter.SchemaRegistryClient")
+    def test_emit_batch_empty_is_noop(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        emitter_config: PgQueueEmitterConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"\x00avro")
+
+        from datahub.pgqueue.emitter import DatahubPgQueueEmitter
+
+        emitter = DatahubPgQueueEmitter(emitter_config)
+
+        with patch.object(emitter, "_repo") as mock_repo:
+            emitter.emit_batch([])
+            mock_repo.enqueue_batch.assert_not_called()

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_headers.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_headers.py
@@ -1,0 +1,18 @@
+"""Kafka-style pgQueue headers JSON codec."""
+
+from __future__ import annotations
+
+from datahub.pgqueue.headers import headers_from_db, headers_to_json
+
+
+def test_headers_round_trip_json() -> None:
+    original = [("a", b"x"), ("b", b"")]
+    js = headers_to_json(original)
+    assert js is not None
+    restored = headers_from_db(js)
+    assert restored == original
+
+
+def test_headers_empty_serializes_to_null_column() -> None:
+    assert headers_to_json(()) is None
+    assert headers_from_db(None) == []

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_host_port.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_host_port.py
@@ -1,0 +1,17 @@
+"""Tests for :mod:`datahub.pgqueue.host_port` (stdlib-only host parsing)."""
+
+from __future__ import annotations
+
+from datahub.pgqueue.host_port import parse_host_port
+
+
+def test_parse_host_port_explicit_port() -> None:
+    assert parse_host_port("localhost:3306") == ("localhost", 3306)
+
+
+def test_parse_host_port_default_port() -> None:
+    assert parse_host_port("localhost", 5432) == ("localhost", 5432)
+
+
+def test_parse_host_port_invalid_port_segment_uses_default() -> None:
+    assert parse_host_port("db.example.com:invalid", 3306) == ("db.example.com", 3306)

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_import_isolation.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_import_isolation.py
@@ -1,0 +1,32 @@
+"""Ensure pgQueue's psycopg2 stack stays isolated from ingestion *sources*."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_pgqueue_import_graph_isolated_from_ingestion_sources() -> None:
+    """Fresh interpreter: package init + repository avoid ingestion sources; lazy exports work."""
+    root = Path(__file__).resolve().parents[2]
+    code = f"""
+import sys
+sys.path.insert(0, {root.as_posix()!r})
+
+import datahub.pgqueue as pq
+assert "datahub.pgqueue.consumer" not in sys.modules
+assert "datahub.pgqueue.emitter" not in sys.modules
+
+import datahub.pgqueue.repository  # noqa: F401
+bad = [k for k in sys.modules if k.startswith("datahub.ingestion.source")]
+assert not bad, "unexpectedly loaded: " + ", ".join(sorted(bad))
+
+_ = pq.DatahubPgQueueConsumer
+assert "datahub.pgqueue.consumer" in sys.modules
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        cwd=root,
+    )

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_init_exports.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_init_exports.py
@@ -1,0 +1,27 @@
+"""Lazy exports on :mod:`datahub.pgqueue`."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "DatahubPgQueueConsumer",
+        "DatahubPgQueueEmitter",
+        "PgQueueConsumedRecord",
+        "build_pg_queue_event_meta",
+    ],
+)
+def test_lazy_getattr_resolves(name: str) -> None:
+    pq = importlib.import_module("datahub.pgqueue")
+    assert getattr(pq, name) is not None
+
+
+def test_unknown_attribute_raises() -> None:
+    pq = importlib.import_module("datahub.pgqueue")
+    with pytest.raises(AttributeError, match="has no attribute"):
+        _ = pq.NotARealExport  # type: ignore[attr-defined]

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_lock_owner.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_lock_owner.py
@@ -1,0 +1,70 @@
+"""Tests for lock_owner format alignment between Python and Java.
+
+Java (PgQueuePollWorker) produces: ``{consumerGroupId}:{UUID}``
+Python (consumer_lock_owner) must match that two-part format.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+from datahub.pgqueue.config import PgQueueConnectionConfig, PgQueueConsumerConfig
+from datahub.pgqueue.connection import consumer_lock_owner
+from datahub.pgqueue.consumer import DatahubPgQueueConsumer
+
+UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+def test_lock_owner_two_part_format() -> None:
+    """Format must be ``{group}:{uuid}`` — no extra segments."""
+    owner = consumer_lock_owner("my-group")
+    group, sep, uuid_part = owner.partition(":")
+    assert sep == ":", f"Expected colon separator in {owner}"
+    assert group == "my-group"
+    assert UUID_RE.match(uuid_part), f"UUID portion is not valid: {uuid_part}"
+
+
+def test_lock_owner_unique_per_call() -> None:
+    a = consumer_lock_owner("g")
+    b = consumer_lock_owner("g")
+    assert a != b, "Each call must produce a distinct lock_owner"
+
+
+def test_lock_owner_preserves_group_name() -> None:
+    owner = consumer_lock_owner("generic-mae-consumer-job-client")
+    assert owner.startswith("generic-mae-consumer-job-client:")
+
+
+def test_consumer_config_no_lock_owner_suffix() -> None:
+    """lock_owner_suffix was removed — config must not accept it."""
+    cfg = PgQueueConsumerConfig(
+        queue=PgQueueConnectionConfig(
+            host_port="localhost:5432",
+            database="db",
+            username="u",
+            password="secret",
+        ),
+    )
+    assert not hasattr(cfg, "lock_owner_suffix")
+
+
+def test_consumer_lock_owner_matches_java_format() -> None:
+    """Consumer instance must produce a lock_owner in Java-aligned format."""
+    queue_cfg = PgQueueConnectionConfig(
+        host_port="localhost:5432",
+        database="db",
+        username="u",
+        password="secret",
+    )
+    cfg = PgQueueConsumerConfig(queue=queue_cfg, consumer_group="test-group")
+    with (
+        patch("datahub.pgqueue.consumer.SchemaRegistryClient"),
+        patch("datahub.pgqueue.consumer.create_pgqueue_connection"),
+    ):
+        consumer = DatahubPgQueueConsumer(cfg)
+        owner = consumer.lock_owner()
+
+    assert owner.startswith("test-group:")
+    uuid_str = owner[len("test-group:") :]
+    assert UUID_RE.match(uuid_str), f"Expected UUID after group prefix, got: {uuid_str}"

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_message_handle_meta.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_message_handle_meta.py
@@ -1,0 +1,57 @@
+"""Round-trip for :class:`~datahub.pgqueue.repository.PgQueueMessageHandle` metadata dicts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from datahub.pgqueue.consumer import (
+    PgQueueConsumedRecord,
+    build_pg_queue_event_meta,
+)
+from datahub.pgqueue.repository import PgQueueMessageHandle, PgQueueReceivedMessage
+
+
+def test_handle_meta_dict_round_trip() -> None:
+    original = PgQueueMessageHandle(
+        id=42,
+        enqueued_at=datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc),
+        topic_id=7,
+        partition_id=3,
+        enqueue_seq=99,
+    )
+    restored = PgQueueMessageHandle.from_meta_dict(original.to_meta_dict())
+    assert restored == original
+
+
+def test_build_pg_queue_event_meta_shape() -> None:
+    handle = PgQueueMessageHandle(
+        id=1,
+        enqueued_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        topic_id=1,
+        partition_id=0,
+        enqueue_seq=5,
+    )
+    raw = PgQueueReceivedMessage(
+        handle=handle,
+        priority=0,
+        payload=b"{}",
+        content_type=None,
+        payload_compression=0,
+        headers=(),
+        routing_key="urn:li:corpuser:test",
+        lock_owner="test:0",
+    )
+    rec = PgQueueConsumedRecord(
+        route_key="mcl",
+        topic_name="MetadataChangeLog_Versioned_v1",
+        raw=raw,
+        record=MagicMock(),
+    )
+    meta = build_pg_queue_event_meta(rec)
+    assert meta["pg_queue"]["topic"] == "MetadataChangeLog_Versioned_v1"
+    assert meta["pg_queue"]["partition"] == 0
+    assert meta["pg_queue"]["enqueue_seq"] == 5
+    assert meta["pg_queue"]["routing_key"] == "urn:li:corpuser:test"
+    round_handle = PgQueueMessageHandle.from_meta_dict(meta["pg_queue"]["handle"])
+    assert round_handle == handle

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_offset_skew.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_offset_skew.py
@@ -1,0 +1,40 @@
+"""Unit tests for pgQueue STUCK_AHEAD detection helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from datahub.pgqueue.offset_skew import PartitionOffsetSkew, warn_if_ahead
+from datahub.pgqueue.repository import PgQueueRepository
+
+
+def test_detect_offset_ahead_of_log_one_cell() -> None:
+    repo = PgQueueRepository("queue", "metadata_queue")
+    conn = MagicMock()
+    cursor_ctx = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cursor_ctx
+
+    cursor_ctx.fetchall.return_value = [(0, 3)]
+    cursor_ctx.fetchone.side_effect = [(10,), (0,)]
+
+    skews = repo.detect_offset_ahead_of_log(
+        conn, "cg", topic_id=1, partition_count=2, topic_name="t"
+    )
+    assert len(skews) == 1
+    assert skews[0].partition_id == 0
+    assert skews[0].ahead_by == 7
+    assert skews[0].topic_name == "t"
+
+
+def test_warn_if_ahead_does_not_raise() -> None:
+    warn_if_ahead(
+        PartitionOffsetSkew(
+            consumer_group="cg",
+            topic_id=1,
+            partition_id=0,
+            committed_offset=10,
+            max_seq=1,
+            ahead_by=9,
+            topic_name="topic",
+        )
+    )

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_partition.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_partition.py
@@ -1,0 +1,17 @@
+from datahub.pgqueue.repository import advisory_lock_key, stable_partition_id
+
+
+def test_stable_partition_id_deterministic() -> None:
+    assert stable_partition_id(
+        "urn:li:dataset:(foo,bar,PROD)", 4
+    ) == stable_partition_id("urn:li:dataset:(foo,bar,PROD)", 4)
+
+
+def test_stable_partition_id_range() -> None:
+    p = stable_partition_id("k", 8)
+    assert 0 <= p < 8
+
+
+def test_advisory_lock_key_stable() -> None:
+    assert advisory_lock_key(1, 0) == advisory_lock_key(1, 0)
+    assert advisory_lock_key(1, 0) != advisory_lock_key(1, 1)

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_priority_bands.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_priority_bands.py
@@ -1,0 +1,406 @@
+"""Tests for per-message priority band configuration and weighted fair queuing."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from datahub.pgqueue.config import (
+    PgQueueConnectionConfig,
+    PgQueueEmitterConfig,
+    PgQueueTopicDefaultsConfig,
+    PgQueueTopicPartialConfig,
+)
+from datahub.pgqueue.priority_bands import (
+    DEFAULT_BANDS_JSON,
+    DEFAULT_PRIORITY,
+    MAX_PRIORITY,
+    MIN_PRIORITY,
+    PRIORITY_BANDS_ENV_VAR,
+    PriorityBand,
+    PriorityBandConfig,
+    resolve_priority_bands_json,
+    weighted_fair_fetch,
+)
+
+
+class TestPriorityBand:
+    def test_valid_band(self) -> None:
+        band = PriorityBand(0, 3, 70)
+        assert band.min_priority == 0
+        assert band.max_priority == 3
+        assert band.weight == 70
+
+    def test_single_priority_band(self) -> None:
+        band = PriorityBand(5, 5, 10)
+        assert band.min_priority == 5
+
+    def test_min_greater_than_max_raises(self) -> None:
+        with pytest.raises(ValueError, match="min_priority"):
+            PriorityBand(5, 3, 10)
+
+    def test_out_of_range_raises(self) -> None:
+        with pytest.raises(ValueError, match="out of range"):
+            PriorityBand(-1, 3, 10)
+        with pytest.raises(ValueError, match="out of range"):
+            PriorityBand(0, 10, 10)
+
+    def test_zero_weight_raises(self) -> None:
+        with pytest.raises(ValueError, match="weight must be positive"):
+            PriorityBand(0, 3, 0)
+
+
+class TestPriorityBandConfig:
+    def test_parse_default(self) -> None:
+        config = PriorityBandConfig.parse(DEFAULT_BANDS_JSON)
+        assert len(config.bands) == 3
+        assert config.bands[0] == PriorityBand(0, 3, 70)
+        assert config.bands[1] == PriorityBand(4, 6, 20)
+        assert config.bands[2] == PriorityBand(7, 9, 10)
+
+    def test_single_band_full_range(self) -> None:
+        config = PriorityBandConfig.parse('[{"range":[0,9],"weight":1}]')
+        assert len(config.bands) == 1
+
+    def test_overlap_raises(self) -> None:
+        with pytest.raises(ValueError, match="overlap"):
+            PriorityBandConfig.parse(
+                '[{"range":[0,5],"weight":50},{"range":[4,9],"weight":50}]'
+            )
+
+    def test_gap_raises(self) -> None:
+        with pytest.raises(ValueError, match="not covered"):
+            PriorityBandConfig.parse(
+                '[{"range":[0,3],"weight":50},{"range":[5,9],"weight":50}]'
+            )
+
+    def test_incomplete_coverage_raises(self) -> None:
+        with pytest.raises(ValueError, match="not covered"):
+            PriorityBandConfig.parse('[{"range":[0,8],"weight":100}]')
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least one"):
+            PriorityBandConfig.parse("[]")
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises((ValueError, json.JSONDecodeError)):
+            PriorityBandConfig.parse("not json")
+
+    def test_batch_limits_proportional(self) -> None:
+        config = PriorityBandConfig.parse(DEFAULT_BANDS_JSON)
+        limits = config.batch_limits(10)
+        assert limits[0] == 7
+        assert limits[1] == 2
+        assert limits[2] == 1
+        assert sum(limits) == 10
+
+    def test_batch_limits_exact(self) -> None:
+        config = PriorityBandConfig.parse(DEFAULT_BANDS_JSON)
+        limits = config.batch_limits(100)
+        assert limits == [70, 20, 10]
+
+    def test_batch_limits_small(self) -> None:
+        config = PriorityBandConfig.parse(DEFAULT_BANDS_JSON)
+        limits = config.batch_limits(3)
+        assert sum(limits) == 3
+        assert limits[0] >= 1
+
+    def test_batch_limits_zero(self) -> None:
+        config = PriorityBandConfig.parse(DEFAULT_BANDS_JSON)
+        limits = config.batch_limits(0)
+        assert limits == [0, 0, 0]
+
+    def test_batch_limits_equal_weights(self) -> None:
+        config = PriorityBandConfig.parse(
+            '[{"range":[0,3],"weight":1},{"range":[4,6],"weight":1},{"range":[7,9],"weight":1}]'
+        )
+        limits = config.batch_limits(9)
+        assert limits == [3, 3, 3]
+
+
+class TestWeightedFairFetch:
+    def test_all_bands_full(self) -> None:
+        config = PriorityBandConfig.parse(DEFAULT_BANDS_JSON)
+        result = weighted_fair_fetch(
+            config,
+            10,
+            lambda min_p, max_p, lim: [f"p{min_p}-{max_p}"] * lim,
+        )
+        assert len(result) == 10
+
+    def test_empty_queue(self) -> None:
+        config = PriorityBandConfig.parse(DEFAULT_BANDS_JSON)
+        result: list[str] = weighted_fair_fetch(
+            config, 10, lambda min_p, max_p, lim: []
+        )
+        assert result == []
+
+    def test_zero_limit(self) -> None:
+        config = PriorityBandConfig.parse(DEFAULT_BANDS_JSON)
+        result = weighted_fair_fetch(
+            config,
+            0,
+            lambda min_p, max_p, lim: ["should-not-be-called"],
+        )
+        assert result == []
+
+    def test_redistribution(self) -> None:
+        config = PriorityBandConfig.parse(DEFAULT_BANDS_JSON)
+
+        def _fetch(min_p: int, max_p: int, lim: int) -> list:
+            if min_p == 0:
+                return ["high"]
+            return [f"other-{i}" for i in range(min(lim, 20))]
+
+        result = weighted_fair_fetch(config, 10, _fetch)
+        assert len(result) == 10
+        assert result[0] == "high"
+
+    def test_single_band_passthrough(self) -> None:
+        config = PriorityBandConfig.parse('[{"range":[0,9],"weight":100}]')
+        calls: list = []
+
+        def _fetch(min_p: int, max_p: int, lim: int) -> list:
+            calls.append((min_p, max_p, lim))
+            return ["a", "b"]
+
+        result = weighted_fair_fetch(config, 5, _fetch)
+        assert len(result) == 2
+        assert calls == [(0, 9, 5)]
+
+
+class TestPriorityConstants:
+    def test_range_is_zero_to_nine(self) -> None:
+        assert MIN_PRIORITY == 0
+        assert MAX_PRIORITY == 9
+
+    def test_default_is_five(self) -> None:
+        assert DEFAULT_PRIORITY == 5
+
+
+class TestPriorityConfigDefaults:
+    """Verify Pydantic config models expose the new priority fields with correct defaults."""
+
+    def test_topic_defaults_has_priority_bands(self) -> None:
+        td = PgQueueTopicDefaultsConfig()
+        assert td.priority_bands is not None
+        parsed = PriorityBandConfig.parse(td.priority_bands)
+        assert len(parsed.bands) == 3
+
+    def test_topic_defaults_no_priority_levels_field(self) -> None:
+        assert "priority_levels" not in PgQueueTopicDefaultsConfig.model_fields
+
+    def test_topic_partial_priority_bands_default_none(self) -> None:
+        tp = PgQueueTopicPartialConfig()
+        assert tp.priority_bands is None
+        assert "priority_levels" not in PgQueueTopicPartialConfig.model_fields
+
+    def test_emitter_default_priority_is_five(self) -> None:
+        cfg = PgQueueEmitterConfig(
+            queue=PgQueueConnectionConfig(
+                host_port="localhost:5432",
+                database="db",
+                username="u",
+                password="p",
+            )
+        )
+        assert cfg.default_priority == 5
+
+    def test_emitter_priority_rejects_above_nine(self) -> None:
+        with pytest.raises(ValidationError):
+            PgQueueEmitterConfig(
+                queue=PgQueueConnectionConfig(
+                    host_port="localhost:5432",
+                    database="db",
+                    username="u",
+                    password="p",
+                ),
+                default_priority=10,
+            )
+
+    def test_emitter_priority_rejects_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            PgQueueEmitterConfig(
+                queue=PgQueueConnectionConfig(
+                    host_port="localhost:5432",
+                    database="db",
+                    username="u",
+                    password="p",
+                ),
+                default_priority=-1,
+            )
+
+    def test_emitter_priority_boundaries_accepted(self) -> None:
+        base_kwargs = dict(
+            queue=PgQueueConnectionConfig(
+                host_port="localhost:5432",
+                database="db",
+                username="u",
+                password="p",
+            ),
+        )
+        cfg0 = PgQueueEmitterConfig(**base_kwargs, default_priority=0)
+        assert cfg0.default_priority == 0
+        cfg9 = PgQueueEmitterConfig(**base_kwargs, default_priority=9)
+        assert cfg9.default_priority == 9
+
+    def test_topic_override_merges_priority_bands(self) -> None:
+        custom_bands = '[{"range":[0,9],"weight":100}]'
+        queue = PgQueueConnectionConfig(
+            host_port="localhost:5432",
+            database="db",
+            username="u",
+            password="p",
+            topic_overrides={
+                "SpecialTopic_v1": PgQueueTopicPartialConfig(
+                    priority_bands=custom_bands,
+                ),
+            },
+        )
+        merged = queue.merged_topic_defaults_for("SpecialTopic_v1")
+        assert merged.priority_bands == custom_bands
+
+        default_merged = queue.merged_topic_defaults_for("Other_v1")
+        assert default_merged.priority_bands == queue.topic_defaults.priority_bands
+
+
+class TestRepositoryPriorityValidation:
+    """Verify repository-level priority bounds checking (mocked, no database)."""
+
+    def test_enqueue_rejects_priority_above_nine(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from datahub.pgqueue.repository import PgQueueRepository
+
+        repo = PgQueueRepository("queue", "metadata_queue")
+        conn = MagicMock()
+        conn.autocommit = True
+
+        with (
+            patch.object(repo, "ensure_topic", return_value=1),
+            patch.object(repo, "fetch_topic_row", return_value=(1, 4, None)),
+            pytest.raises(ValueError, match="out of range"),
+        ):
+            repo.enqueue(
+                conn,
+                topic_name="t",
+                routing_key="k",
+                partition_count=4,
+                retention_max_age_seconds=0,
+                max_rows_per_topic=0,
+                max_total_payload_bytes=0,
+                default_content_type_mime=None,
+                priority=10,
+                payload=b"x",
+                content_type=None,
+                headers=(),
+            )
+
+    def test_enqueue_rejects_negative_priority(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from datahub.pgqueue.repository import PgQueueRepository
+
+        repo = PgQueueRepository("queue", "metadata_queue")
+        conn = MagicMock()
+        conn.autocommit = True
+
+        with (
+            patch.object(repo, "ensure_topic", return_value=1),
+            patch.object(repo, "fetch_topic_row", return_value=(1, 4, None)),
+            pytest.raises(ValueError, match="out of range"),
+        ):
+            repo.enqueue(
+                conn,
+                topic_name="t",
+                routing_key="k",
+                partition_count=4,
+                retention_max_age_seconds=0,
+                max_rows_per_topic=0,
+                max_total_payload_bytes=0,
+                default_content_type_mime=None,
+                priority=-1,
+                payload=b"x",
+                content_type=None,
+                headers=(),
+            )
+
+
+class TestResolvePriorityBandsJson:
+    """Tests for the priority bands resolution hierarchy:
+    GMS server config → ENV override → hardcoded default.
+    """
+
+    def test_returns_hardcoded_default_when_no_sources(self) -> None:
+        result = resolve_priority_bands_json(server_config=None, env_override=None)
+        assert result == DEFAULT_BANDS_JSON
+
+    def test_env_override_wins_over_hardcoded_default(self) -> None:
+        custom = '[{"range":[0,9],"weight":100}]'
+        result = resolve_priority_bands_json(server_config=None, env_override=custom)
+        assert result == custom
+
+    def test_server_config_wins_over_env(self) -> None:
+        server_bands = '[{"range":[0,4],"weight":60},{"range":[5,9],"weight":40}]'
+        env_bands = '[{"range":[0,9],"weight":100}]'
+        server_config = {"pgQueue": {"priorityBands": server_bands}}
+        result = resolve_priority_bands_json(
+            server_config=server_config, env_override=env_bands
+        )
+        assert result == server_bands
+
+    def test_server_config_missing_pgqueue_key_falls_to_env(self) -> None:
+        env_bands = '[{"range":[0,9],"weight":100}]'
+        server_config = {"datahub": {"serverType": "prod"}}
+        result = resolve_priority_bands_json(
+            server_config=server_config, env_override=env_bands
+        )
+        assert result == env_bands
+
+    def test_server_config_pgqueue_missing_prioritybands_falls_to_env(self) -> None:
+        env_bands = '[{"range":[0,9],"weight":100}]'
+        server_config = {"pgQueue": {"someOtherKey": "value"}}
+        result = resolve_priority_bands_json(
+            server_config=server_config, env_override=env_bands
+        )
+        assert result == env_bands
+
+    def test_server_config_empty_prioritybands_falls_to_env(self) -> None:
+        env_bands = '[{"range":[0,9],"weight":100}]'
+        server_config = {"pgQueue": {"priorityBands": ""}}
+        result = resolve_priority_bands_json(
+            server_config=server_config, env_override=env_bands
+        )
+        assert result == env_bands
+
+    def test_server_config_non_string_prioritybands_falls_to_env(self) -> None:
+        env_bands = '[{"range":[0,9],"weight":100}]'
+        server_config = {"pgQueue": {"priorityBands": 123}}
+        result = resolve_priority_bands_json(
+            server_config=server_config, env_override=env_bands
+        )
+        assert result == env_bands
+
+    def test_reads_from_os_environ_when_env_override_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        custom = '[{"range":[0,9],"weight":100}]'
+        monkeypatch.setenv(PRIORITY_BANDS_ENV_VAR, custom)
+        result = resolve_priority_bands_json(server_config=None, env_override=None)
+        assert result == custom
+
+    def test_empty_env_var_falls_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PRIORITY_BANDS_ENV_VAR, "")
+        result = resolve_priority_bands_json(server_config=None, env_override=None)
+        assert result == DEFAULT_BANDS_JSON
+
+    def test_server_config_none_pgqueue_falls_through(self) -> None:
+        server_config = {"pgQueue": None}
+        result = resolve_priority_bands_json(
+            server_config=server_config, env_override=None
+        )
+        assert result == DEFAULT_BANDS_JSON

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_repository.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_repository.py
@@ -1,0 +1,113 @@
+"""Unit tests for :mod:`datahub.pgqueue.repository` batch helpers (no database)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from datahub.pgqueue.repository import (
+    EnqueueBatchItem,
+    PgQueueMessageHandle,
+    PgQueueRepository,
+)
+
+
+def test_enqueue_batch_empty_returns_without_db_round_trip() -> None:
+    repo = PgQueueRepository("queue", "metadata_queue")
+    conn = MagicMock()
+    assert (
+        repo.enqueue_batch(
+            conn,
+            [],
+            partition_count=2,
+            retention_max_age_seconds=0,
+            max_rows_per_topic=0,
+            max_total_payload_bytes=0,
+        )
+        == []
+    )
+    conn.cursor.assert_not_called()
+
+
+def test_enqueue_batch_commits_once() -> None:
+    repo = PgQueueRepository("queue", "metadata_queue")
+    conn = MagicMock()
+    conn.autocommit = True
+    dummy = PgQueueMessageHandle(
+        id=1,
+        enqueued_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        topic_id=1,
+        partition_id=0,
+        enqueue_seq=1,
+    )
+    items = [
+        EnqueueBatchItem(
+            topic_name="t",
+            routing_key="a",
+            priority=0,
+            payload=b"x",
+            content_type=None,
+            headers=(),
+        ),
+        EnqueueBatchItem(
+            topic_name="t",
+            routing_key="b",
+            priority=0,
+            payload=b"y",
+            content_type=None,
+            headers=(),
+        ),
+    ]
+    with patch.object(repo, "_enqueue_message_in_transaction", return_value=dummy):
+        repo.enqueue_batch(
+            conn,
+            items,
+            partition_count=4,
+            retention_max_age_seconds=86400,
+            max_rows_per_topic=1_000_000,
+            max_total_payload_bytes=10**12,
+        )
+    conn.commit.assert_called_once()
+    conn.rollback.assert_not_called()
+
+
+def test_receive_batch_for_group_flush_pg_connection_before_autocommit_toggle() -> None:
+    """Implicit transactions (e.g. after ``fetch_topic_row``) block ``set_session``."""
+    repo = PgQueueRepository("queue", "metadata_queue")
+    conn = MagicMock()
+    conn.autocommit = True
+    cursor_ctx = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cursor_ctx
+    cursor_ctx.fetchall.return_value = []
+    with (
+        patch("datahub.pgqueue.repository.flush_pg_connection") as flush,
+        patch.object(repo, "_receive_partition_for_group", return_value=[]),
+    ):
+        repo.receive_batch_for_group(
+            conn,
+            consumer_group="cg",
+            topic_id=1,
+            partition_ids=(0,),
+            lock_owner="g:1",
+            visibility_timeout=timedelta(seconds=30),
+            max_messages=10,
+        )
+    flush.assert_called_once_with(conn)
+
+
+def test_receive_batch_for_group_zero_skips_cursor() -> None:
+    repo = PgQueueRepository("queue", "metadata_queue")
+    conn = MagicMock()
+    assert (
+        repo.receive_batch_for_group(
+            conn,
+            consumer_group="cg",
+            topic_id=1,
+            partition_ids=(0, 1),
+            lock_owner="g:1",
+            visibility_timeout=timedelta(seconds=30),
+            max_messages=0,
+        )
+        == []
+    )
+    conn.cursor.assert_not_called()

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_repository_sql.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_repository_sql.py
@@ -1,0 +1,256 @@
+"""Repository SQL paths with mocked psycopg2 cursors (no live database)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub.pgqueue.repository import PgQueueMessageHandle, PgQueueRepository
+
+
+def _repo() -> PgQueueRepository:
+    return PgQueueRepository("queue", "metadata_queue")
+
+
+def _cursor_conn(cur: MagicMock) -> MagicMock:
+    conn = MagicMock()
+    conn.autocommit = True
+    conn.cursor.return_value.__enter__.return_value = cur
+    return conn
+
+
+def _handle(
+    msg_id: int = 1,
+    *,
+    topic_id: int = 10,
+    partition_id: int = 0,
+    enqueue_seq: int = 42,
+) -> PgQueueMessageHandle:
+    return PgQueueMessageHandle(
+        id=msg_id,
+        enqueued_at=datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc),
+        topic_id=topic_id,
+        partition_id=partition_id,
+        enqueue_seq=enqueue_seq,
+    )
+
+
+class TestFetchTopicRow:
+    def test_returns_none_when_missing(self) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = None
+        conn = _cursor_conn(cur)
+
+        assert _repo().fetch_topic_row(conn, "MissingTopic") is None
+
+    def test_parses_row(self) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = (7, 4, 3)
+        conn = _cursor_conn(cur)
+
+        row = _repo().fetch_topic_row(conn, "MetadataChangeProposal_v1")
+        assert row == (7, 4, 3)
+
+    def test_null_default_content_type(self) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = (1, 2, None)
+        conn = _cursor_conn(cur)
+
+        row = _repo().fetch_topic_row(conn, "t")
+        assert row == (1, 2, None)
+
+
+class TestEnsureTopic:
+    def test_upsert_and_select_id(self) -> None:
+        mime_cur = MagicMock()
+        mime_cur.fetchone.return_value = (2,)
+        topic_cur = MagicMock()
+        topic_cur.fetchone.return_value = (99,)
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.side_effect = [mime_cur, topic_cur]
+
+        topic_id = _repo().ensure_topic(
+            conn,
+            "MetadataChangeProposal_v1",
+            partition_count=4,
+            retention_max_age_seconds=86400,
+            max_rows_per_topic=1_000_000,
+            max_total_payload_bytes=1_000_000_000,
+        )
+
+        assert topic_id == 99
+        assert mime_cur.execute.call_count == 2
+        assert topic_cur.execute.call_count == 2
+
+
+class TestEnqueueMessageInTransaction:
+    def test_priority_out_of_range(self) -> None:
+        repo = _repo()
+        conn = MagicMock()
+        with (
+            patch.object(repo, "ensure_topic", return_value=1),
+            patch.object(repo, "fetch_topic_row", return_value=(1, 4, None)),
+            pytest.raises(ValueError, match="priority"),
+        ):
+            repo._enqueue_message_in_transaction(
+                conn,
+                topic_name="t",
+                routing_key="urn:li:dataset:1",
+                partition_count=4,
+                retention_max_age_seconds=1,
+                max_rows_per_topic=1,
+                max_total_payload_bytes=1,
+                default_content_type_mime=None,
+                priority=10,
+                payload=b"x",
+                content_type=None,
+                headers=(),
+            )
+
+    def test_inserts_and_returns_handle(self) -> None:
+        repo = _repo()
+        enq_at = datetime(2024, 1, 2, tzinfo=timezone.utc)
+        cur = MagicMock()
+        cur.fetchone.return_value = (55, enq_at, 7)
+        conn = _cursor_conn(cur)
+
+        with (
+            patch.object(repo, "ensure_topic", return_value=10),
+            patch.object(repo, "fetch_topic_row", return_value=(10, 8, 3)),
+            patch.object(repo, "_compute_stored_content_type_id", return_value=None),
+        ):
+            handle = repo._enqueue_message_in_transaction(
+                conn,
+                topic_name="MetadataChangeProposal_v1",
+                routing_key="urn:li:dataset:(urn:li:dataPlatform:mysql,db.t,PROD)",
+                partition_count=8,
+                retention_max_age_seconds=86400,
+                max_rows_per_topic=1_000_000,
+                max_total_payload_bytes=1_000_000_000,
+                default_content_type_mime="application/avro",
+                priority=0,
+                payload=b"\x00avro",
+                content_type=None,
+                headers=(),
+            )
+
+        assert handle.id == 55
+        assert handle.topic_id == 10
+        assert handle.enqueue_seq == 7
+        assert cur.execute.call_count == 2
+
+
+class TestComputeStoredContentType:
+    def test_none_when_no_content_type(self) -> None:
+        assert _repo()._compute_stored_content_type_id(MagicMock(), 1, None) is None
+
+    def test_none_when_matches_topic_default(self) -> None:
+        repo = _repo()
+        with patch.object(repo, "_ensure_mime_registered", return_value=5) as mock_mime:
+            assert (
+                repo._compute_stored_content_type_id(MagicMock(), 5, "application/json")
+                is None
+            )
+        mock_mime.assert_called_once()
+
+    def test_returns_id_when_differs_from_default(self) -> None:
+        repo = _repo()
+        with patch.object(repo, "_ensure_mime_registered", return_value=9):
+            assert (
+                repo._compute_stored_content_type_id(MagicMock(), 5, "text/plain") == 9
+            )
+
+
+@patch("datahub.pgqueue.repository.restore_pg_connection_autocommit")
+@patch("datahub.pgqueue.repository.flush_pg_connection")
+class TestTransactionalRepositoryMethods:
+    def test_enqueue_commits(self, _flush: MagicMock, _restore: MagicMock) -> None:
+        repo = _repo()
+        conn = MagicMock()
+        conn.autocommit = True
+        expected = _handle(msg_id=77)
+
+        with patch.object(
+            repo, "_enqueue_message_in_transaction", return_value=expected
+        ):
+            result = repo.enqueue(
+                conn,
+                topic_name="t",
+                routing_key="k",
+                partition_count=4,
+                retention_max_age_seconds=1,
+                max_rows_per_topic=1,
+                max_total_payload_bytes=1,
+                priority=0,
+                payload=b"p",
+                content_type=None,
+                headers=(),
+            )
+
+        assert result is expected
+        conn.commit.assert_called_once()
+
+    def test_commit_for_group_advances_offsets(
+        self, _flush: MagicMock, _restore: MagicMock
+    ) -> None:
+        repo = _repo()
+        conn = MagicMock()
+        conn.autocommit = True
+        cur = MagicMock()
+        cur.rowcount = 2
+        conn.cursor.return_value.__enter__.return_value = cur
+        handles = [
+            _handle(1, topic_id=10, partition_id=0, enqueue_seq=5),
+            _handle(2, topic_id=10, partition_id=0, enqueue_seq=8),
+        ]
+
+        deleted = repo.commit_for_group(conn, "my-group", handles)
+
+        assert deleted == 2
+        conn.commit.assert_called_once()
+        # DELETE + one UPSERT per (topic_id, partition_id)
+        assert cur.execute.call_count == 2
+
+    def test_commit_for_group_empty_is_noop(
+        self, _flush: MagicMock, _restore: MagicMock
+    ) -> None:
+        assert _repo().commit_for_group(MagicMock(), "g", []) == 0
+
+    def test_extend_visibility_updates_leases(
+        self, _flush: MagicMock, _restore: MagicMock
+    ) -> None:
+        from datetime import timedelta
+
+        repo = _repo()
+        conn = MagicMock()
+        conn.autocommit = True
+        cur = MagicMock()
+        cur.rowcount = 1
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        updated = repo.extend_visibility_for_group(
+            conn,
+            "my-group",
+            [_handle()],
+            lock_owner="my-group:uuid",
+            extend_by=timedelta(seconds=60),
+        )
+
+        assert updated == 1
+        conn.commit.assert_called_once()
+
+    def test_register_consumer_upserts(
+        self, _flush: MagicMock, _restore: MagicMock
+    ) -> None:
+        repo = _repo()
+        conn = MagicMock()
+        conn.autocommit = True
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        repo.register_consumer(conn, "pipeline-1", topic_id=42)
+
+        cur.execute.assert_called_once()
+        conn.commit.assert_called_once()

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_sink.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_sink.py
@@ -1,0 +1,117 @@
+"""Tests for the pgQueue sink (DatahubPgQueueSink)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import RecordEnvelope
+from datahub.ingestion.sink.datahub_pg_queue import DatahubPgQueueSink
+from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
+from datahub.metadata.schema_classes import (
+    ChangeTypeClass,
+    DatasetSnapshotClass,
+    MetadataChangeProposalClass,
+    StatusClass,
+)
+
+
+@pytest.fixture()
+def sink() -> DatahubPgQueueSink:
+    with patch(
+        "datahub.ingestion.sink.datahub_pg_queue.DatahubPgQueueEmitter"
+    ) as mock_cls:
+        mock_emitter = MagicMock()
+        mock_cls.return_value = mock_emitter
+        config = {
+            "queue": {
+                "host_port": "localhost:5432",
+                "database": "datahub",
+                "username": "datahub",
+                "password": "datahub",
+            }
+        }
+        s = DatahubPgQueueSink.create(config, MagicMock())
+        assert s.emitter is mock_emitter
+        return s
+
+
+def test_write_record_async_mcp_wrapper(sink: DatahubPgQueueSink) -> None:
+    mcp = MetadataChangeProposalWrapper(
+        entityUrn="urn:li:dataset:(urn:li:dataPlatform:hive,mydb.table,PROD)",
+        aspect=StatusClass(removed=False),
+    )
+    envelope: RecordEnvelope[Any] = RecordEnvelope(record=mcp, metadata={})
+    callback = MagicMock()
+
+    sink.write_record_async(envelope, callback)
+
+    mock_emitter: Any = sink.emitter
+    mock_emitter.emit.assert_called_once()
+    assert mock_emitter.emit.call_args[0][0] is mcp
+
+
+def test_write_record_async_mcp_class(sink: DatahubPgQueueSink) -> None:
+    mcp = MetadataChangeProposalClass(
+        entityType="dataset",
+        changeType=ChangeTypeClass.UPSERT,
+        entityUrn="urn:li:dataset:(urn:li:dataPlatform:hive,mydb.table,PROD)",
+    )
+    envelope: RecordEnvelope[Any] = RecordEnvelope(record=mcp, metadata={})
+    callback = MagicMock()
+
+    sink.write_record_async(envelope, callback)
+
+    mock_emitter: Any = sink.emitter
+    mock_emitter.emit.assert_called_once()
+    assert mock_emitter.emit.call_args[0][0] is mcp
+
+
+def test_write_record_async_mce_calls_emit_batch(sink: DatahubPgQueueSink) -> None:
+    snapshot = DatasetSnapshotClass(
+        urn="urn:li:dataset:(urn:li:dataPlatform:hive,mydb.table,PROD)",
+        aspects=[StatusClass(removed=False)],
+    )
+    mce = MetadataChangeEvent(proposedSnapshot=snapshot)
+    envelope: RecordEnvelope[Any] = RecordEnvelope(record=mce, metadata={})
+    callback = MagicMock()
+
+    sink.write_record_async(envelope, callback)
+
+    mock_emitter: Any = sink.emitter
+    mock_emitter.emit_batch.assert_called_once()
+    mcps = mock_emitter.emit_batch.call_args[0][0]
+    assert len(mcps) >= 1
+
+
+def test_write_record_async_mce_zero_aspects(sink: DatahubPgQueueSink) -> None:
+    snapshot = DatasetSnapshotClass(
+        urn="urn:li:dataset:(urn:li:dataPlatform:hive,mydb.table,PROD)",
+        aspects=[],
+    )
+    mce = MetadataChangeEvent(proposedSnapshot=snapshot)
+    envelope: RecordEnvelope[Any] = RecordEnvelope(record=mce, metadata={})
+    callback = MagicMock()
+
+    sink.write_record_async(envelope, callback)
+
+    mock_emitter: Any = sink.emitter
+    mock_emitter.emit_batch.assert_not_called()
+    callback.on_success.assert_called_once()
+
+
+def test_close_calls_emitter_close(sink: DatahubPgQueueSink) -> None:
+    sink.close()
+
+    mock_emitter: Any = sink.emitter
+    mock_emitter.close.assert_called_once()
+
+
+def test_handle_work_unit_end_flushes(sink: DatahubPgQueueSink) -> None:
+    sink.handle_work_unit_end(MagicMock())
+
+    mock_emitter: Any = sink.emitter
+    mock_emitter.flush.assert_called_once()

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_sql.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_sql.py
@@ -1,0 +1,26 @@
+import pytest
+
+from datahub.pgqueue.sql import qualified_table, quote_ident, validate_pg_identifier
+
+
+def test_quote_ident_basic() -> None:
+    assert quote_ident("queue") == '"queue"'
+    assert quote_ident("metadata_queue") == '"metadata_queue"'
+
+
+def test_validate_pg_identifier_rejects_bad() -> None:
+    with pytest.raises(ValueError):
+        validate_pg_identifier("bad-name", "x")
+    with pytest.raises(ValueError):
+        validate_pg_identifier("", "x")
+
+
+def test_qualified_table() -> None:
+    assert qualified_table("queue", "metadata_queue", "topic") == (
+        '"queue"."metadata_queue_topic"'
+    )
+
+
+def test_qualified_table_rejects_injection_attempt() -> None:
+    with pytest.raises(ValueError):
+        qualified_table("queue;drop", "metadata_queue", "topic")

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -34,6 +34,7 @@ dependencies = [
     { name = "click" },
     { name = "click-default-group" },
     { name = "click-spinner" },
+    { name = "cramjam" },
     { name = "deprecated" },
     { name = "docker" },
     { name = "expandvars" },
@@ -474,6 +475,14 @@ datahub-lite = [
     { name = "fastapi" },
     { name = "uvicorn" },
 ]
+datahub-pg-queue = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "confluent-kafka", extra = ["avro", "schemaregistry"] },
+    { name = "fastavro" },
+    { name = "psycopg2-binary" },
+    { name = "urllib3" },
+]
 datahub-rest = [
     { name = "graphql-core" },
     { name = "requests" },
@@ -575,6 +584,7 @@ dev = [
     { name = "clickhouse-sqlalchemy" },
     { name = "confluent-kafka", extra = ["avro", "schemaregistry"] },
     { name = "coverage" },
+    { name = "cramjam" },
     { name = "cryptography" },
     { name = "dask", extra = ["dataframe"] },
     { name = "databricks-dbapi" },
@@ -772,6 +782,7 @@ docs = [
     { name = "clickhouse-sqlalchemy" },
     { name = "confluent-kafka", extra = ["avro", "schemaregistry"] },
     { name = "coverage" },
+    { name = "cramjam" },
     { name = "cryptography" },
     { name = "dask", extra = ["dataframe"] },
     { name = "databricks-dbapi" },
@@ -2128,6 +2139,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'cockroachdb'", specifier = ">=1.35.0,<2.0.0" },
     { name = "boto3", marker = "extra == 'confluence'", specifier = ">=1.35.0,<2.0.0" },
     { name = "boto3", marker = "extra == 'datahub-documents'", specifier = ">=1.35.0,<2.0.0" },
+    { name = "boto3", marker = "extra == 'datahub-pg-queue'", specifier = ">=1.35.0,<2.0.0" },
     { name = "boto3", marker = "extra == 'dbt'", specifier = ">=1.35.0,<2.0.0" },
     { name = "boto3", marker = "extra == 'delta-lake'", specifier = ">=1.35.0,<2.0.0" },
     { name = "boto3", marker = "extra == 'dev'", specifier = ">=1.35.0,<2.0.0" },
@@ -2156,6 +2168,7 @@ requires-dist = [
     { name = "botocore", marker = "extra == 'cockroachdb'", specifier = "!=1.23.0,<2.0.0" },
     { name = "botocore", marker = "extra == 'confluence'", specifier = "!=1.23.0,<2.0.0" },
     { name = "botocore", marker = "extra == 'datahub-documents'", specifier = "!=1.23.0,<2.0.0" },
+    { name = "botocore", marker = "extra == 'datahub-pg-queue'", specifier = "!=1.23.0,<2.0.0" },
     { name = "botocore", marker = "extra == 'dbt'", specifier = "!=1.23.0,<2.0.0" },
     { name = "botocore", marker = "extra == 'delta-lake'", specifier = "!=1.23.0,<2.0.0" },
     { name = "botocore", marker = "extra == 'dev'", specifier = "!=1.23.0,<2.0.0" },
@@ -2262,11 +2275,15 @@ requires-dist = [
     { name = "confluent-kafka", extras = ["avro", "schemaregistry"], marker = "extra == 'all'", specifier = "!=2.8.1,>=2.10.1,<2.13.0" },
     { name = "confluent-kafka", extras = ["avro", "schemaregistry"], marker = "extra == 'datahub'", specifier = ">=2.10.1,<2.13.0" },
     { name = "confluent-kafka", extras = ["avro", "schemaregistry"], marker = "extra == 'datahub-kafka'", specifier = ">=1.9.0,!=2.8.1,<3.0.0" },
+    { name = "confluent-kafka", extras = ["avro", "schemaregistry"], marker = "extra == 'datahub-pg-queue'", specifier = ">=1.9.0,!=2.8.1,<3.0.0" },
     { name = "confluent-kafka", extras = ["avro", "schemaregistry"], marker = "extra == 'dev'", specifier = ">=2.10.1,<2.13.0" },
     { name = "confluent-kafka", extras = ["avro", "schemaregistry"], marker = "extra == 'docs'", specifier = ">=2.10.1,<2.13.0" },
     { name = "confluent-kafka", extras = ["avro", "schemaregistry"], marker = "extra == 'kafka'", specifier = ">=2.10.1,<2.13.0" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=5.1,<8.0.0" },
     { name = "coverage", marker = "extra == 'docs'", specifier = ">=5.1,<8.0.0" },
+    { name = "cramjam", specifier = ">=2.8.0,<3.0.0" },
+    { name = "cramjam", marker = "extra == 'dev'", specifier = ">=2.8.0,<3.0.0" },
+    { name = "cramjam", marker = "extra == 'docs'", specifier = ">=2.8.0,<3.0.0" },
     { name = "cryptography", marker = "extra == 'all'", specifier = ">=46.0.7,<47.0.0" },
     { name = "cryptography", marker = "extra == 'dev'", specifier = ">=46.0.7,<47.0.0" },
     { name = "cryptography", marker = "extra == 'docs'", specifier = ">=46.0.7,<47.0.0" },
@@ -2351,6 +2368,7 @@ requires-dist = [
     { name = "fastavro", marker = "extra == 'all'", specifier = ">=1.2.0,<2.0.0" },
     { name = "fastavro", marker = "extra == 'datahub'", specifier = ">=1.2.0,<2.0.0" },
     { name = "fastavro", marker = "extra == 'datahub-kafka'", specifier = ">=1.2.0,<2.0.0" },
+    { name = "fastavro", marker = "extra == 'datahub-pg-queue'", specifier = ">=1.2.0,<2.0.0" },
     { name = "fastavro", marker = "extra == 'dev'", specifier = ">=1.2.0,<2.0.0" },
     { name = "fastavro", marker = "extra == 'docs'", specifier = ">=1.2.0,<2.0.0" },
     { name = "fastavro", marker = "extra == 'kafka'", specifier = ">=1.2.0,<2.0.0" },
@@ -2892,6 +2910,7 @@ requires-dist = [
     { name = "psutil", marker = "extra == 'docs'", specifier = ">=5.8.0,<8.0.0" },
     { name = "psycopg2-binary", marker = "extra == 'all'", specifier = "<3.0.0" },
     { name = "psycopg2-binary", marker = "extra == 'cockroachdb'", specifier = "<3.0.0" },
+    { name = "psycopg2-binary", marker = "extra == 'datahub-pg-queue'", specifier = "<3.0.0" },
     { name = "psycopg2-binary", marker = "extra == 'dev'", specifier = "<3.0.0" },
     { name = "psycopg2-binary", marker = "extra == 'docs'", specifier = "<3.0.0" },
     { name = "psycopg2-binary", marker = "extra == 'hive-metastore'", specifier = "<3.0.0" },
@@ -3576,6 +3595,7 @@ requires-dist = [
     { name = "urllib3", marker = "extra == 'cockroachdb'", specifier = ">=1.26,<3.0" },
     { name = "urllib3", marker = "extra == 'confluence'", specifier = ">=1.26,<3.0" },
     { name = "urllib3", marker = "extra == 'datahub-documents'", specifier = ">=1.26,<3.0" },
+    { name = "urllib3", marker = "extra == 'datahub-pg-queue'", specifier = ">=1.26,<3.0" },
     { name = "urllib3", marker = "extra == 'dbt'", specifier = ">=1.26,<3.0" },
     { name = "urllib3", marker = "extra == 'delta-lake'", specifier = ">=1.26,<3.0" },
     { name = "urllib3", marker = "extra == 'dev'", specifier = ">=1.26,<3.0" },
@@ -3636,7 +3656,7 @@ requires-dist = [
     { name = "zstd", marker = "extra == 'docs'", specifier = "<1.5.6.8" },
     { name = "zstd", marker = "extra == 'integration-tests'", specifier = "<1.5.6.8" },
 ]
-provides-extras = ["base", "abs", "abs-slim", "aerospike", "athena", "aws-secret-manager", "azure-ad", "azure-data-factory", "bigquery", "bigquery-queries", "bigquery-slim", "cassandra", "circuit-breaker", "clickhouse", "clickhouse-usage", "cockroachdb", "confluence", "databricks", "datahub", "datahub-business-glossary", "datahub-debug", "datahub-documents", "datahub-gc", "datahub-kafka", "datahub-lineage-file", "datahub-lite", "datahub-rest", "dataplex", "db2", "dbt", "dbt-cloud", "debug-recording", "delta-lake", "dlt", "doris", "dremio", "druid", "dynamodb", "elasticsearch", "excel", "fabric-data-factory", "fabric-onelake", "feast", "fivetran", "flink", "gcp-secret-manager", "gcs", "gcs-slim", "glue", "grafana", "hana", "hive", "hive-metastore", "iceberg", "iceberg-catalog", "informatica", "json-schema", "kafka", "kafka-connect", "ldap", "looker", "lookml", "mariadb", "matillion-dpc", "metabase", "mlflow", "mode", "mongodb", "mssql", "mssql-odbc", "mysql", "neo4j", "nifi", "notion", "okta", "omni", "oracle", "pinecone", "postgres", "powerbi", "powerbi-report-server", "preset", "presto", "presto-on-hive", "pulsar", "qlik-sense", "rdf", "redash", "redshift", "redshift-slim", "s3", "s3-slim", "sac", "sagemaker", "salesforce", "sigma", "slack", "snaplogic", "snowflake", "snowflake-queries", "snowflake-slim", "snowflake-summary", "snowplow", "sql-parser", "sql-queries", "sqlalchemy", "starburst-trino-usage", "starrocks", "superset", "sync-file-emitter", "tableau", "teradata", "trino", "unity-catalog", "unstructured", "vertexai", "vertica", "all", "cloud", "dev", "docs", "lint", "testing-utils", "integration-tests", "debug"]
+provides-extras = ["base", "abs", "abs-slim", "aerospike", "athena", "aws-secret-manager", "azure-ad", "azure-data-factory", "bigquery", "bigquery-queries", "bigquery-slim", "cassandra", "circuit-breaker", "clickhouse", "clickhouse-usage", "cockroachdb", "confluence", "databricks", "datahub", "datahub-business-glossary", "datahub-debug", "datahub-documents", "datahub-gc", "datahub-kafka", "datahub-lineage-file", "datahub-lite", "datahub-pg-queue", "datahub-rest", "dataplex", "db2", "dbt", "dbt-cloud", "debug-recording", "delta-lake", "dlt", "doris", "dremio", "druid", "dynamodb", "elasticsearch", "excel", "fabric-data-factory", "fabric-onelake", "feast", "fivetran", "flink", "gcp-secret-manager", "gcs", "gcs-slim", "glue", "grafana", "hana", "hive", "hive-metastore", "iceberg", "iceberg-catalog", "informatica", "json-schema", "kafka", "kafka-connect", "ldap", "looker", "lookml", "mariadb", "matillion-dpc", "metabase", "mlflow", "mode", "mongodb", "mssql", "mssql-odbc", "mysql", "neo4j", "nifi", "notion", "okta", "omni", "oracle", "pinecone", "postgres", "powerbi", "powerbi-report-server", "preset", "presto", "presto-on-hive", "pulsar", "qlik-sense", "rdf", "redash", "redshift", "redshift-slim", "s3", "s3-slim", "sac", "sagemaker", "salesforce", "sigma", "slack", "snaplogic", "snowflake", "snowflake-queries", "snowflake-slim", "snowflake-summary", "snowplow", "sql-parser", "sql-queries", "sqlalchemy", "starburst-trino-usage", "starrocks", "superset", "sync-file-emitter", "tableau", "teradata", "trino", "unity-catalog", "unstructured", "vertexai", "vertica", "all", "cloud", "dev", "docs", "lint", "testing-utils", "integration-tests", "debug"]
 
 [[package]]
 name = "acryl-datahub-classify"

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
@@ -679,6 +679,13 @@ public class JavaEntityClient implements EntityClient {
     return entityService.exists(opContext, urn, includeSoftDelete);
   }
 
+  @Override
+  public Set<Urn> filterExistingUrns(
+      @Nonnull OperationContext opContext, @Nonnull Collection<Urn> urns)
+      throws RemoteInvocationException {
+    return entityService.exists(opContext, urns, true);
+  }
+
   @SneakyThrows
   @Override
   @Deprecated

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -2958,6 +2958,12 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
           collectMetrics(opContext.getMetricUtils().orElse(null), exceptions).toString());
     }
 
+    // Hard delete wipes all aspects in one shot; capture propertyDefinition before deleteUrn so
+    // PropertyDefinitionDeleteSideEffect can scroll ES and emit PATCH REMOVE MCPs (see
+    // docs/api/tutorials/structured-properties.md).
+    final RecordTemplate[] propertyDefinitionBeforeHardDelete = {null};
+    final SystemMetadata[] propertyDefinitionMetadataBeforeHardDelete = {null};
+
     final RollbackResult result =
         aspectDao
             .runInTransactionWithRetry(
@@ -3080,6 +3086,25 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                       if (hardDelete) {
                         // If this is the key aspect, delete the entity entirely.
                         // If Using CDCs, need to ensure key aspect is the deleted last.
+                        if (STRUCTURED_PROPERTY_ENTITY_NAME.equals(entityUrn.getEntityType())) {
+                          try {
+                            SystemAspect definitionAspect =
+                                aspectDao.getLatestAspect(
+                                    opContext,
+                                    urn,
+                                    STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
+                                    false);
+                            propertyDefinitionBeforeHardDelete[0] =
+                                definitionAspect.getRecordTemplate();
+                            propertyDefinitionMetadataBeforeHardDelete[0] =
+                                definitionAspect.getSystemMetadata();
+                          } catch (EntityNotFoundException e) {
+                            log.debug(
+                                "No {} aspect to capture before hard delete of {}",
+                                STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
+                                urn);
+                          }
+                        }
                         additionalRowsDeleted = aspectDao.deleteUrn(opContext, txContext, urn);
                       } else if (deleteItem
                           .getEntitySpec()
@@ -3146,7 +3171,23 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
             .orElse(null);
 
     if (result != null) {
-      processPostCommitMCLSideEffects(opContext, List.of(result.toMCL(auditStamp)));
+      List<MetadataChangeLog> mclsForSideEffects = new ArrayList<>();
+      if (propertyDefinitionBeforeHardDelete[0] != null) {
+        mclsForSideEffects.add(
+            constructMCL(
+                null,
+                urnToEntityName(entityUrn),
+                entityUrn,
+                ChangeType.DELETE,
+                STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
+                auditStamp,
+                null,
+                null,
+                propertyDefinitionBeforeHardDelete[0],
+                propertyDefinitionMetadataBeforeHardDelete[0]));
+      }
+      mclsForSideEffects.add(result.toMCL(auditStamp));
+      processPostCommitMCLSideEffects(opContext, mclsForSideEffects);
     }
 
     return result;

--- a/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/hooks/PropertyDefinitionDeleteSideEffect.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/hooks/PropertyDefinitionDeleteSideEffect.java
@@ -66,15 +66,22 @@ public class PropertyDefinitionDeleteSideEffect extends MCPSideEffect {
           mclItem.getAuditStamp(),
           retrieverContext);
     } else if (STRUCTURED_PROPERTY_KEY_ASPECT_NAME.equals(mclItem.getAspectName())) {
+      // Hard delete emits only a key-aspect DELETE MCL after deleteUrn wipes the DB. Cleanup is
+      // driven by a companion propertyDefinition DELETE MCL with previousAspect (see
+      // EntityServiceImpl.deleteAspectWithoutMCL).
       Aspect definitionAspect =
           retrieverContext
               .getAspectRetriever()
               .getLatestAspectObject(mclItem.getUrn(), STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME);
+      if (definitionAspect == null) {
+        log.debug(
+            "Skipping assignment cleanup for {} key delete; definition already removed",
+            mclItem.getUrn());
+        return Stream.empty();
+      }
       return generatePatchMCPs(
           mclItem.getUrn(),
-          definitionAspect == null
-              ? null
-              : new StructuredPropertyDefinition(definitionAspect.data()),
+          new StructuredPropertyDefinition(definitionAspect.data()),
           mclItem.getAuditStamp(),
           retrieverContext);
     }
@@ -91,6 +98,10 @@ public class PropertyDefinitionDeleteSideEffect extends MCPSideEffect {
       @Nullable StructuredPropertyDefinition definition,
       @Nullable AuditStamp auditStamp,
       @Nonnull RetrieverContext retrieverContext) {
+    if (definition == null) {
+      log.debug("Skipping assignment cleanup for {}; no propertyDefinition available", propertyUrn);
+      return Stream.empty();
+    }
     EntityWithPropertyIterator iterator =
         EntityWithPropertyIterator.builder()
             .propertyUrn(propertyUrn)

--- a/metadata-io/src/test/java/com/linkedin/metadata/structuredproperties/hooks/PropertyDefinitionDeleteSideEffectTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/structuredproperties/hooks/PropertyDefinitionDeleteSideEffectTest.java
@@ -140,6 +140,34 @@ public class PropertyDefinitionDeleteSideEffectTest {
   }
 
   @Test
+  public void testDeletePropertyKeyWithoutDefinitionSkipsCleanup() {
+    PropertyDefinitionDeleteSideEffect test = new PropertyDefinitionDeleteSideEffect();
+    test.setConfig(TEST_PLUGIN_CONFIG);
+
+    when(mockAspectRetriever.getLatestAspectObject(
+            eq(TEST_PROPERTY_URN), eq(STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME)))
+        .thenReturn(null);
+
+    List<MCPItem> result =
+        test.postMCPSideEffect(
+                Set.of(
+                    TestMCL.builder()
+                        .changeType(ChangeType.DELETE)
+                        .urn(TEST_PROPERTY_URN)
+                        .entitySpec(TEST_REGISTRY.getEntitySpec("structuredProperty"))
+                        .aspectSpec(
+                            TEST_REGISTRY
+                                .getEntitySpec("structuredProperty")
+                                .getAspectSpec(STRUCTURED_PROPERTY_KEY_ASPECT_NAME))
+                        .build()),
+                retrieverContext)
+            .collect(Collectors.toList());
+
+    assertEquals(0, result.size());
+    verify(mockSearchRetriever, times(0)).scroll(any(), any(), nullable(String.class), anyInt());
+  }
+
+  @Test
   public void testDeletePropertyDefinition() {
     PropertyDefinitionDeleteSideEffect test = new PropertyDefinitionDeleteSideEffect();
     test.setConfig(TEST_PLUGIN_CONFIG);

--- a/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -543,6 +543,15 @@ public interface EntityClient {
       @Nonnull OperationContext opContext, @Nonnull Urn urn, @Nonnull Boolean includeSoftDelete)
       throws RemoteInvocationException;
 
+  /**
+   * Returns the subset of urns whose entities exist (have materialized aspects, not hard-deleted).
+   *
+   * @param urns urns to check
+   * @return urns that exist
+   */
+  Set<Urn> filterExistingUrns(@Nonnull OperationContext opContext, @Nonnull Collection<Urn> urns)
+      throws RemoteInvocationException;
+
   @Nullable
   @Deprecated
   VersionedAspect getAspect(

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -89,6 +89,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -969,6 +970,20 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             .urnParam(urn.toString())
             .includeSoftDeleteParam(includeSoftDeleted);
     return sendClientRequest(requestBuilder, opContext).getEntity();
+  }
+
+  @Override
+  @Nonnull
+  public Set<Urn> filterExistingUrns(
+      @Nonnull OperationContext opContext, @Nonnull Collection<Urn> urns)
+      throws RemoteInvocationException {
+    Set<Urn> existing = new HashSet<>();
+    for (Urn urn : urns) {
+      if (exists(opContext, urn)) {
+        existing.add(urn);
+      }
+    }
+    return existing;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds Python `pgqueue` client library and `datahub_pg_queue` ingestion sink
- Adds `pg_queue` event source for datahub-actions
- Includes structured-properties fix bundled at stack base

## Stack
Bottom PR in pgQueue stack. Next: `chore/pgqueue-dev-infra` → this branch.

## Test plan
- [x] `./gradlew :metadata-ingestion:testQuick` (via prior validation)

Made with [Cursor](https://cursor.com)