### PR TITLE
chore(docker): remove legacy compose stack and document profiles workflow

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -34,7 +34,7 @@ which are continuously deployed to [Docker Hub](https://hub.docker.com/u/acrylda
 You can easily download and run all these images and their dependencies with our
 [quick start guide](../docs/quickstart.md).
 
-**Compose layout:** Quickstart and local development use [Docker Compose profiles](https://github.com/datahub-project/datahub/blob/master/docker/profiles/README.md) under
+**Compose layout:** Quickstart and local development use [Docker Compose profiles](profiles/docker-compose.yml) under
 `docker/profiles/`. The CLI downloads a flattened compose file at
 `docker/quickstart/docker-compose.quickstart-profile.yml`. Legacy root-level `docker-compose*.yml` files and shell
 scripts (`quickstart.sh`, `dev.sh`, `nuke.sh`) have been removed.

--- a/docker/datahub-gms/README.md
+++ b/docker/datahub-gms/README.md
@@ -20,4 +20,4 @@ For example, use Docker Compose profiles under `docker/profiles/`:
 cd docker/profiles && docker compose --profile quickstart-postgres up
 ```
 
-See [`docker/profiles/README.md`](https://github.com/datahub-project/datahub/blob/master/docker/profiles/README.md) for all profile options.
+See `docker/profiles/README.md` in the repository for all profile options.

--- a/docs/docker/development.md
+++ b/docs/docker/development.md
@@ -1,9 +1,9 @@
 # Using Docker Images During Development
 
-Local development uses [Docker Compose profiles](https://github.com/datahub-project/datahub/blob/master/docker/profiles/README.md) under `docker/profiles/`. The `debug`
+Local development uses [Docker Compose profiles](../../docker/profiles/docker-compose.yml) under `docker/profiles/`. The `debug`
 profile mounts locally built artifacts into containers tagged `debug`, so you avoid rebuilding images on every change.
 
-We highly recommend `./gradlew quickstartDebug` (or [`scripts/dev/datahub-dev.sh`](https://github.com/datahub-project/datahub/blob/master/scripts/dev/datahub-dev.sh) for agent workflows).
+We highly recommend `./gradlew quickstartDebug` (or [`scripts/dev/datahub-dev.sh`](../../scripts/dev/datahub-dev.sh) for agent workflows).
 
 ```shell
 ./gradlew quickstartDebug
@@ -149,4 +149,4 @@ To start only GMS without dependencies:
 docker compose --project-directory docker/profiles --profile debug -p datahub up --no-deps datahub-gms
 ```
 
-See [`docker/profiles/README.md`](https://github.com/datahub-project/datahub/blob/master/docker/profiles/README.md) for available profiles.
+See `docker/profiles/README.md` in the repository for available profiles.


### PR DESCRIPTION
## Summary

- Delete obsolete root `docker/docker-compose*.yml` files, `docker/quickstart.sh`, `docker/dev*.sh`, `docker/nuke.sh`, legacy quickstart generator tooling, and old generated quickstart bundles (kept `docker-compose.quickstart-profile.yml` only).
- Keep `docker/profiles/` and Gradle/`datahub-dev` as the canonical local development path.
- Update docs (README, quickstart, development, plugins, auth, monitoring, deploy/aws, datahub-web-react) and add a breaking-change note in `docs/how/updating-datahub.md`.

## Test plan

- [x] Pre-commit `Check quickstart docker-compose config is up-to-date` passed
- [x] Grep shows no stale doc links to deleted compose paths (analytics-agent `quickstart.sh` is unrelated)
- [ ] CI: `verify-quickstart-compose`, `quickstart-test`, `docker-unified`


Made with [Cursor](https://cursor.com)